### PR TITLE
Use jsoniter instead of json in example

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -1,10 +1,10 @@
 package jsoniter_test
 
 import (
+	"encoding/json"
 	"fmt"
 	"github.com/json-iterator/go"
 	"os"
-	"encoding/json"
 )
 
 func ExampleMarshal() {
@@ -33,13 +33,13 @@ func ExampleUnmarshal() {
 		{"Name": "Quoll",    "Order": "Dasyuromorphia"}
 	]`)
 	type Animal struct {
-	Name  string
-	Order string
+		Name  string
+		Order string
 	}
 	var animals []Animal
-	err := json.Unmarshal(jsonBlob, &animals)
+	err := jsoniter.Unmarshal(jsonBlob, &animals)
 	if err != nil {
-	fmt.Println("error:", err)
+		fmt.Println("error:", err)
 	}
 	fmt.Printf("%+v", animals)
 	// Output:

--- a/example_test.go
+++ b/example_test.go
@@ -1,10 +1,10 @@
 package jsoniter_test
 
 import (
-	"encoding/json"
 	"fmt"
-	"github.com/json-iterator/go"
 	"os"
+
+	"github.com/json-iterator/go"
 )
 
 func ExampleMarshal() {


### PR DESCRIPTION
As an example, I think jsoniter should be used instead json from standard lib.