### PR TITLE
WIP: Tests to compare against stdlib

### DIFF
--- a/output_tests/builtins/bool/json_test.go
+++ b/output_tests/builtins/bool/json_test.go
@@ -1,0 +1,144 @@
+package test
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/davecgh/go-spew/spew"
+	fuzz "github.com/google/gofuzz"
+	jsoniter "github.com/json-iterator/go"
+)
+
+func Test_Roundtrip(t *testing.T) {
+	fz := fuzz.New().MaxDepth(10).NilChance(0.3)
+	for i := 0; i < 1000; i++ {
+		var before T
+		fz.Fuzz(&before)
+
+		jbStd, err := json.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with stdlib: %v", err)
+		}
+		jbIter, err := jsoniter.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with jsoniter: %v", err)
+		}
+		if string(jbStd) != string(jbIter) {
+			t.Errorf("marshal expected:\n    %s\ngot:\n    %s\nobj:\n    %s",
+				indent(jbStd, "    "), indent(jbIter, "    "), dump(before))
+		}
+
+		var afterStd T
+		err = json.Unmarshal(jbIter, &afterStd)
+		if err != nil {
+			t.Errorf("failed to unmarshal with stdlib: %v", err)
+		}
+		var afterIter T
+		err = jsoniter.Unmarshal(jbIter, &afterIter)
+		if err != nil {
+			t.Errorf("failed to unmarshal with jsoniter: %v", err)
+		}
+		if fingerprint(afterStd) != fingerprint(afterIter) {
+			t.Errorf("unmarshal expected:\n    %s\ngot:\n    %s\nvia:\n    %s",
+				dump(afterStd), dump(afterIter), indent(jbIter, "    "))
+		}
+	}
+}
+
+const indentStr = ">  "
+
+func fingerprint(obj interface{}) string {
+	c := spew.ConfigState{
+		SortKeys: true,
+		SpewKeys: true,
+	}
+	return c.Sprintf("%v", obj)
+}
+
+func dump(obj interface{}) string {
+	cfg := spew.ConfigState{
+		Indent: indentStr,
+	}
+	return cfg.Sdump(obj)
+}
+
+func indent(src []byte, prefix string) string {
+	var buf bytes.Buffer
+	json.Indent(&buf, src, prefix, indentStr)
+	return buf.String()
+}
+
+func BenchmarkStandardMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := json.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkStandardUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = json.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}
+
+func BenchmarkJSONIterMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := jsoniter.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkJSONIterUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = jsoniter.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}

--- a/output_tests/builtins/bool/types.go
+++ b/output_tests/builtins/bool/types.go
@@ -1,0 +1,3 @@
+package test
+
+type T bool

--- a/output_tests/builtins/bool_alias/json_test.go
+++ b/output_tests/builtins/bool_alias/json_test.go
@@ -1,0 +1,144 @@
+package test
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/davecgh/go-spew/spew"
+	fuzz "github.com/google/gofuzz"
+	jsoniter "github.com/json-iterator/go"
+)
+
+func Test_Roundtrip(t *testing.T) {
+	fz := fuzz.New().MaxDepth(10).NilChance(0.3)
+	for i := 0; i < 1000; i++ {
+		var before T
+		fz.Fuzz(&before)
+
+		jbStd, err := json.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with stdlib: %v", err)
+		}
+		jbIter, err := jsoniter.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with jsoniter: %v", err)
+		}
+		if string(jbStd) != string(jbIter) {
+			t.Errorf("marshal expected:\n    %s\ngot:\n    %s\nobj:\n    %s",
+				indent(jbStd, "    "), indent(jbIter, "    "), dump(before))
+		}
+
+		var afterStd T
+		err = json.Unmarshal(jbIter, &afterStd)
+		if err != nil {
+			t.Errorf("failed to unmarshal with stdlib: %v", err)
+		}
+		var afterIter T
+		err = jsoniter.Unmarshal(jbIter, &afterIter)
+		if err != nil {
+			t.Errorf("failed to unmarshal with jsoniter: %v", err)
+		}
+		if fingerprint(afterStd) != fingerprint(afterIter) {
+			t.Errorf("unmarshal expected:\n    %s\ngot:\n    %s\nvia:\n    %s",
+				dump(afterStd), dump(afterIter), indent(jbIter, "    "))
+		}
+	}
+}
+
+const indentStr = ">  "
+
+func fingerprint(obj interface{}) string {
+	c := spew.ConfigState{
+		SortKeys: true,
+		SpewKeys: true,
+	}
+	return c.Sprintf("%v", obj)
+}
+
+func dump(obj interface{}) string {
+	cfg := spew.ConfigState{
+		Indent: indentStr,
+	}
+	return cfg.Sdump(obj)
+}
+
+func indent(src []byte, prefix string) string {
+	var buf bytes.Buffer
+	json.Indent(&buf, src, prefix, indentStr)
+	return buf.String()
+}
+
+func BenchmarkStandardMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := json.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkStandardUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = json.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}
+
+func BenchmarkJSONIterMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := jsoniter.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkJSONIterUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = jsoniter.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}

--- a/output_tests/builtins/bool_alias/types.go
+++ b/output_tests/builtins/bool_alias/types.go
@@ -1,0 +1,3 @@
+package test
+
+type T bool

--- a/output_tests/builtins/byte/json_test.go
+++ b/output_tests/builtins/byte/json_test.go
@@ -1,0 +1,144 @@
+package test
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/davecgh/go-spew/spew"
+	fuzz "github.com/google/gofuzz"
+	jsoniter "github.com/json-iterator/go"
+)
+
+func Test_Roundtrip(t *testing.T) {
+	fz := fuzz.New().MaxDepth(10).NilChance(0.3)
+	for i := 0; i < 1000; i++ {
+		var before T
+		fz.Fuzz(&before)
+
+		jbStd, err := json.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with stdlib: %v", err)
+		}
+		jbIter, err := jsoniter.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with jsoniter: %v", err)
+		}
+		if string(jbStd) != string(jbIter) {
+			t.Errorf("marshal expected:\n    %s\ngot:\n    %s\nobj:\n    %s",
+				indent(jbStd, "    "), indent(jbIter, "    "), dump(before))
+		}
+
+		var afterStd T
+		err = json.Unmarshal(jbIter, &afterStd)
+		if err != nil {
+			t.Errorf("failed to unmarshal with stdlib: %v", err)
+		}
+		var afterIter T
+		err = jsoniter.Unmarshal(jbIter, &afterIter)
+		if err != nil {
+			t.Errorf("failed to unmarshal with jsoniter: %v", err)
+		}
+		if fingerprint(afterStd) != fingerprint(afterIter) {
+			t.Errorf("unmarshal expected:\n    %s\ngot:\n    %s\nvia:\n    %s",
+				dump(afterStd), dump(afterIter), indent(jbIter, "    "))
+		}
+	}
+}
+
+const indentStr = ">  "
+
+func fingerprint(obj interface{}) string {
+	c := spew.ConfigState{
+		SortKeys: true,
+		SpewKeys: true,
+	}
+	return c.Sprintf("%v", obj)
+}
+
+func dump(obj interface{}) string {
+	cfg := spew.ConfigState{
+		Indent: indentStr,
+	}
+	return cfg.Sdump(obj)
+}
+
+func indent(src []byte, prefix string) string {
+	var buf bytes.Buffer
+	json.Indent(&buf, src, prefix, indentStr)
+	return buf.String()
+}
+
+func BenchmarkStandardMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := json.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkStandardUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = json.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}
+
+func BenchmarkJSONIterMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := jsoniter.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkJSONIterUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = jsoniter.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}

--- a/output_tests/builtins/byte/types.go
+++ b/output_tests/builtins/byte/types.go
@@ -1,0 +1,3 @@
+package test
+
+type T byte

--- a/output_tests/builtins/byte_alias/json_test.go
+++ b/output_tests/builtins/byte_alias/json_test.go
@@ -1,0 +1,144 @@
+package test
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/davecgh/go-spew/spew"
+	fuzz "github.com/google/gofuzz"
+	jsoniter "github.com/json-iterator/go"
+)
+
+func Test_Roundtrip(t *testing.T) {
+	fz := fuzz.New().MaxDepth(10).NilChance(0.3)
+	for i := 0; i < 1000; i++ {
+		var before T
+		fz.Fuzz(&before)
+
+		jbStd, err := json.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with stdlib: %v", err)
+		}
+		jbIter, err := jsoniter.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with jsoniter: %v", err)
+		}
+		if string(jbStd) != string(jbIter) {
+			t.Errorf("marshal expected:\n    %s\ngot:\n    %s\nobj:\n    %s",
+				indent(jbStd, "    "), indent(jbIter, "    "), dump(before))
+		}
+
+		var afterStd T
+		err = json.Unmarshal(jbIter, &afterStd)
+		if err != nil {
+			t.Errorf("failed to unmarshal with stdlib: %v", err)
+		}
+		var afterIter T
+		err = jsoniter.Unmarshal(jbIter, &afterIter)
+		if err != nil {
+			t.Errorf("failed to unmarshal with jsoniter: %v", err)
+		}
+		if fingerprint(afterStd) != fingerprint(afterIter) {
+			t.Errorf("unmarshal expected:\n    %s\ngot:\n    %s\nvia:\n    %s",
+				dump(afterStd), dump(afterIter), indent(jbIter, "    "))
+		}
+	}
+}
+
+const indentStr = ">  "
+
+func fingerprint(obj interface{}) string {
+	c := spew.ConfigState{
+		SortKeys: true,
+		SpewKeys: true,
+	}
+	return c.Sprintf("%v", obj)
+}
+
+func dump(obj interface{}) string {
+	cfg := spew.ConfigState{
+		Indent: indentStr,
+	}
+	return cfg.Sdump(obj)
+}
+
+func indent(src []byte, prefix string) string {
+	var buf bytes.Buffer
+	json.Indent(&buf, src, prefix, indentStr)
+	return buf.String()
+}
+
+func BenchmarkStandardMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := json.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkStandardUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = json.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}
+
+func BenchmarkJSONIterMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := jsoniter.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkJSONIterUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = jsoniter.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}

--- a/output_tests/builtins/byte_alias/types.go
+++ b/output_tests/builtins/byte_alias/types.go
@@ -1,0 +1,3 @@
+package test
+
+type T byte

--- a/output_tests/builtins/float32/json_test.go
+++ b/output_tests/builtins/float32/json_test.go
@@ -1,0 +1,144 @@
+package test
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/davecgh/go-spew/spew"
+	fuzz "github.com/google/gofuzz"
+	jsoniter "github.com/json-iterator/go"
+)
+
+func Test_Roundtrip(t *testing.T) {
+	fz := fuzz.New().MaxDepth(10).NilChance(0.3)
+	for i := 0; i < 1000; i++ {
+		var before T
+		fz.Fuzz(&before)
+
+		jbStd, err := json.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with stdlib: %v", err)
+		}
+		jbIter, err := jsoniter.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with jsoniter: %v", err)
+		}
+		if string(jbStd) != string(jbIter) {
+			t.Errorf("marshal expected:\n    %s\ngot:\n    %s\nobj:\n    %s",
+				indent(jbStd, "    "), indent(jbIter, "    "), dump(before))
+		}
+
+		var afterStd T
+		err = json.Unmarshal(jbIter, &afterStd)
+		if err != nil {
+			t.Errorf("failed to unmarshal with stdlib: %v", err)
+		}
+		var afterIter T
+		err = jsoniter.Unmarshal(jbIter, &afterIter)
+		if err != nil {
+			t.Errorf("failed to unmarshal with jsoniter: %v", err)
+		}
+		if fingerprint(afterStd) != fingerprint(afterIter) {
+			t.Errorf("unmarshal expected:\n    %s\ngot:\n    %s\nvia:\n    %s",
+				dump(afterStd), dump(afterIter), indent(jbIter, "    "))
+		}
+	}
+}
+
+const indentStr = ">  "
+
+func fingerprint(obj interface{}) string {
+	c := spew.ConfigState{
+		SortKeys: true,
+		SpewKeys: true,
+	}
+	return c.Sprintf("%v", obj)
+}
+
+func dump(obj interface{}) string {
+	cfg := spew.ConfigState{
+		Indent: indentStr,
+	}
+	return cfg.Sdump(obj)
+}
+
+func indent(src []byte, prefix string) string {
+	var buf bytes.Buffer
+	json.Indent(&buf, src, prefix, indentStr)
+	return buf.String()
+}
+
+func BenchmarkStandardMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := json.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkStandardUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = json.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}
+
+func BenchmarkJSONIterMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := jsoniter.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkJSONIterUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = jsoniter.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}

--- a/output_tests/builtins/float32/types.go
+++ b/output_tests/builtins/float32/types.go
@@ -1,0 +1,3 @@
+package test
+
+type T float32

--- a/output_tests/builtins/float32_alias/json_test.go
+++ b/output_tests/builtins/float32_alias/json_test.go
@@ -1,0 +1,144 @@
+package test
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/davecgh/go-spew/spew"
+	fuzz "github.com/google/gofuzz"
+	jsoniter "github.com/json-iterator/go"
+)
+
+func Test_Roundtrip(t *testing.T) {
+	fz := fuzz.New().MaxDepth(10).NilChance(0.3)
+	for i := 0; i < 1000; i++ {
+		var before T
+		fz.Fuzz(&before)
+
+		jbStd, err := json.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with stdlib: %v", err)
+		}
+		jbIter, err := jsoniter.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with jsoniter: %v", err)
+		}
+		if string(jbStd) != string(jbIter) {
+			t.Errorf("marshal expected:\n    %s\ngot:\n    %s\nobj:\n    %s",
+				indent(jbStd, "    "), indent(jbIter, "    "), dump(before))
+		}
+
+		var afterStd T
+		err = json.Unmarshal(jbIter, &afterStd)
+		if err != nil {
+			t.Errorf("failed to unmarshal with stdlib: %v", err)
+		}
+		var afterIter T
+		err = jsoniter.Unmarshal(jbIter, &afterIter)
+		if err != nil {
+			t.Errorf("failed to unmarshal with jsoniter: %v", err)
+		}
+		if fingerprint(afterStd) != fingerprint(afterIter) {
+			t.Errorf("unmarshal expected:\n    %s\ngot:\n    %s\nvia:\n    %s",
+				dump(afterStd), dump(afterIter), indent(jbIter, "    "))
+		}
+	}
+}
+
+const indentStr = ">  "
+
+func fingerprint(obj interface{}) string {
+	c := spew.ConfigState{
+		SortKeys: true,
+		SpewKeys: true,
+	}
+	return c.Sprintf("%v", obj)
+}
+
+func dump(obj interface{}) string {
+	cfg := spew.ConfigState{
+		Indent: indentStr,
+	}
+	return cfg.Sdump(obj)
+}
+
+func indent(src []byte, prefix string) string {
+	var buf bytes.Buffer
+	json.Indent(&buf, src, prefix, indentStr)
+	return buf.String()
+}
+
+func BenchmarkStandardMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := json.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkStandardUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = json.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}
+
+func BenchmarkJSONIterMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := jsoniter.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkJSONIterUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = jsoniter.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}

--- a/output_tests/builtins/float32_alias/types.go
+++ b/output_tests/builtins/float32_alias/types.go
@@ -1,0 +1,3 @@
+package test
+
+type T float32

--- a/output_tests/builtins/float64/json_test.go
+++ b/output_tests/builtins/float64/json_test.go
@@ -1,0 +1,144 @@
+package test
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/davecgh/go-spew/spew"
+	fuzz "github.com/google/gofuzz"
+	jsoniter "github.com/json-iterator/go"
+)
+
+func Test_Roundtrip(t *testing.T) {
+	fz := fuzz.New().MaxDepth(10).NilChance(0.3)
+	for i := 0; i < 1000; i++ {
+		var before T
+		fz.Fuzz(&before)
+
+		jbStd, err := json.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with stdlib: %v", err)
+		}
+		jbIter, err := jsoniter.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with jsoniter: %v", err)
+		}
+		if string(jbStd) != string(jbIter) {
+			t.Errorf("marshal expected:\n    %s\ngot:\n    %s\nobj:\n    %s",
+				indent(jbStd, "    "), indent(jbIter, "    "), dump(before))
+		}
+
+		var afterStd T
+		err = json.Unmarshal(jbIter, &afterStd)
+		if err != nil {
+			t.Errorf("failed to unmarshal with stdlib: %v", err)
+		}
+		var afterIter T
+		err = jsoniter.Unmarshal(jbIter, &afterIter)
+		if err != nil {
+			t.Errorf("failed to unmarshal with jsoniter: %v", err)
+		}
+		if fingerprint(afterStd) != fingerprint(afterIter) {
+			t.Errorf("unmarshal expected:\n    %s\ngot:\n    %s\nvia:\n    %s",
+				dump(afterStd), dump(afterIter), indent(jbIter, "    "))
+		}
+	}
+}
+
+const indentStr = ">  "
+
+func fingerprint(obj interface{}) string {
+	c := spew.ConfigState{
+		SortKeys: true,
+		SpewKeys: true,
+	}
+	return c.Sprintf("%v", obj)
+}
+
+func dump(obj interface{}) string {
+	cfg := spew.ConfigState{
+		Indent: indentStr,
+	}
+	return cfg.Sdump(obj)
+}
+
+func indent(src []byte, prefix string) string {
+	var buf bytes.Buffer
+	json.Indent(&buf, src, prefix, indentStr)
+	return buf.String()
+}
+
+func BenchmarkStandardMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := json.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkStandardUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = json.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}
+
+func BenchmarkJSONIterMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := jsoniter.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkJSONIterUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = jsoniter.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}

--- a/output_tests/builtins/float64/types.go
+++ b/output_tests/builtins/float64/types.go
@@ -1,0 +1,3 @@
+package test
+
+type T float64

--- a/output_tests/builtins/float64_alias/json_test.go
+++ b/output_tests/builtins/float64_alias/json_test.go
@@ -1,0 +1,144 @@
+package test
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/davecgh/go-spew/spew"
+	fuzz "github.com/google/gofuzz"
+	jsoniter "github.com/json-iterator/go"
+)
+
+func Test_Roundtrip(t *testing.T) {
+	fz := fuzz.New().MaxDepth(10).NilChance(0.3)
+	for i := 0; i < 1000; i++ {
+		var before T
+		fz.Fuzz(&before)
+
+		jbStd, err := json.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with stdlib: %v", err)
+		}
+		jbIter, err := jsoniter.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with jsoniter: %v", err)
+		}
+		if string(jbStd) != string(jbIter) {
+			t.Errorf("marshal expected:\n    %s\ngot:\n    %s\nobj:\n    %s",
+				indent(jbStd, "    "), indent(jbIter, "    "), dump(before))
+		}
+
+		var afterStd T
+		err = json.Unmarshal(jbIter, &afterStd)
+		if err != nil {
+			t.Errorf("failed to unmarshal with stdlib: %v", err)
+		}
+		var afterIter T
+		err = jsoniter.Unmarshal(jbIter, &afterIter)
+		if err != nil {
+			t.Errorf("failed to unmarshal with jsoniter: %v", err)
+		}
+		if fingerprint(afterStd) != fingerprint(afterIter) {
+			t.Errorf("unmarshal expected:\n    %s\ngot:\n    %s\nvia:\n    %s",
+				dump(afterStd), dump(afterIter), indent(jbIter, "    "))
+		}
+	}
+}
+
+const indentStr = ">  "
+
+func fingerprint(obj interface{}) string {
+	c := spew.ConfigState{
+		SortKeys: true,
+		SpewKeys: true,
+	}
+	return c.Sprintf("%v", obj)
+}
+
+func dump(obj interface{}) string {
+	cfg := spew.ConfigState{
+		Indent: indentStr,
+	}
+	return cfg.Sdump(obj)
+}
+
+func indent(src []byte, prefix string) string {
+	var buf bytes.Buffer
+	json.Indent(&buf, src, prefix, indentStr)
+	return buf.String()
+}
+
+func BenchmarkStandardMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := json.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkStandardUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = json.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}
+
+func BenchmarkJSONIterMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := jsoniter.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkJSONIterUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = jsoniter.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}

--- a/output_tests/builtins/float64_alias/types.go
+++ b/output_tests/builtins/float64_alias/types.go
@@ -1,0 +1,3 @@
+package test
+
+type T float64

--- a/output_tests/builtins/int16/json_test.go
+++ b/output_tests/builtins/int16/json_test.go
@@ -1,0 +1,144 @@
+package test
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/davecgh/go-spew/spew"
+	fuzz "github.com/google/gofuzz"
+	jsoniter "github.com/json-iterator/go"
+)
+
+func Test_Roundtrip(t *testing.T) {
+	fz := fuzz.New().MaxDepth(10).NilChance(0.3)
+	for i := 0; i < 1000; i++ {
+		var before T
+		fz.Fuzz(&before)
+
+		jbStd, err := json.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with stdlib: %v", err)
+		}
+		jbIter, err := jsoniter.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with jsoniter: %v", err)
+		}
+		if string(jbStd) != string(jbIter) {
+			t.Errorf("marshal expected:\n    %s\ngot:\n    %s\nobj:\n    %s",
+				indent(jbStd, "    "), indent(jbIter, "    "), dump(before))
+		}
+
+		var afterStd T
+		err = json.Unmarshal(jbIter, &afterStd)
+		if err != nil {
+			t.Errorf("failed to unmarshal with stdlib: %v", err)
+		}
+		var afterIter T
+		err = jsoniter.Unmarshal(jbIter, &afterIter)
+		if err != nil {
+			t.Errorf("failed to unmarshal with jsoniter: %v", err)
+		}
+		if fingerprint(afterStd) != fingerprint(afterIter) {
+			t.Errorf("unmarshal expected:\n    %s\ngot:\n    %s\nvia:\n    %s",
+				dump(afterStd), dump(afterIter), indent(jbIter, "    "))
+		}
+	}
+}
+
+const indentStr = ">  "
+
+func fingerprint(obj interface{}) string {
+	c := spew.ConfigState{
+		SortKeys: true,
+		SpewKeys: true,
+	}
+	return c.Sprintf("%v", obj)
+}
+
+func dump(obj interface{}) string {
+	cfg := spew.ConfigState{
+		Indent: indentStr,
+	}
+	return cfg.Sdump(obj)
+}
+
+func indent(src []byte, prefix string) string {
+	var buf bytes.Buffer
+	json.Indent(&buf, src, prefix, indentStr)
+	return buf.String()
+}
+
+func BenchmarkStandardMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := json.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkStandardUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = json.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}
+
+func BenchmarkJSONIterMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := jsoniter.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkJSONIterUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = jsoniter.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}

--- a/output_tests/builtins/int16/types.go
+++ b/output_tests/builtins/int16/types.go
@@ -1,0 +1,3 @@
+package test
+
+type T int16

--- a/output_tests/builtins/int16_alias/json_test.go
+++ b/output_tests/builtins/int16_alias/json_test.go
@@ -1,0 +1,144 @@
+package test
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/davecgh/go-spew/spew"
+	fuzz "github.com/google/gofuzz"
+	jsoniter "github.com/json-iterator/go"
+)
+
+func Test_Roundtrip(t *testing.T) {
+	fz := fuzz.New().MaxDepth(10).NilChance(0.3)
+	for i := 0; i < 1000; i++ {
+		var before T
+		fz.Fuzz(&before)
+
+		jbStd, err := json.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with stdlib: %v", err)
+		}
+		jbIter, err := jsoniter.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with jsoniter: %v", err)
+		}
+		if string(jbStd) != string(jbIter) {
+			t.Errorf("marshal expected:\n    %s\ngot:\n    %s\nobj:\n    %s",
+				indent(jbStd, "    "), indent(jbIter, "    "), dump(before))
+		}
+
+		var afterStd T
+		err = json.Unmarshal(jbIter, &afterStd)
+		if err != nil {
+			t.Errorf("failed to unmarshal with stdlib: %v", err)
+		}
+		var afterIter T
+		err = jsoniter.Unmarshal(jbIter, &afterIter)
+		if err != nil {
+			t.Errorf("failed to unmarshal with jsoniter: %v", err)
+		}
+		if fingerprint(afterStd) != fingerprint(afterIter) {
+			t.Errorf("unmarshal expected:\n    %s\ngot:\n    %s\nvia:\n    %s",
+				dump(afterStd), dump(afterIter), indent(jbIter, "    "))
+		}
+	}
+}
+
+const indentStr = ">  "
+
+func fingerprint(obj interface{}) string {
+	c := spew.ConfigState{
+		SortKeys: true,
+		SpewKeys: true,
+	}
+	return c.Sprintf("%v", obj)
+}
+
+func dump(obj interface{}) string {
+	cfg := spew.ConfigState{
+		Indent: indentStr,
+	}
+	return cfg.Sdump(obj)
+}
+
+func indent(src []byte, prefix string) string {
+	var buf bytes.Buffer
+	json.Indent(&buf, src, prefix, indentStr)
+	return buf.String()
+}
+
+func BenchmarkStandardMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := json.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkStandardUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = json.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}
+
+func BenchmarkJSONIterMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := jsoniter.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkJSONIterUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = jsoniter.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}

--- a/output_tests/builtins/int16_alias/types.go
+++ b/output_tests/builtins/int16_alias/types.go
@@ -1,0 +1,3 @@
+package test
+
+type T int16

--- a/output_tests/builtins/int32/json_test.go
+++ b/output_tests/builtins/int32/json_test.go
@@ -1,0 +1,144 @@
+package test
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/davecgh/go-spew/spew"
+	fuzz "github.com/google/gofuzz"
+	jsoniter "github.com/json-iterator/go"
+)
+
+func Test_Roundtrip(t *testing.T) {
+	fz := fuzz.New().MaxDepth(10).NilChance(0.3)
+	for i := 0; i < 1000; i++ {
+		var before T
+		fz.Fuzz(&before)
+
+		jbStd, err := json.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with stdlib: %v", err)
+		}
+		jbIter, err := jsoniter.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with jsoniter: %v", err)
+		}
+		if string(jbStd) != string(jbIter) {
+			t.Errorf("marshal expected:\n    %s\ngot:\n    %s\nobj:\n    %s",
+				indent(jbStd, "    "), indent(jbIter, "    "), dump(before))
+		}
+
+		var afterStd T
+		err = json.Unmarshal(jbIter, &afterStd)
+		if err != nil {
+			t.Errorf("failed to unmarshal with stdlib: %v", err)
+		}
+		var afterIter T
+		err = jsoniter.Unmarshal(jbIter, &afterIter)
+		if err != nil {
+			t.Errorf("failed to unmarshal with jsoniter: %v", err)
+		}
+		if fingerprint(afterStd) != fingerprint(afterIter) {
+			t.Errorf("unmarshal expected:\n    %s\ngot:\n    %s\nvia:\n    %s",
+				dump(afterStd), dump(afterIter), indent(jbIter, "    "))
+		}
+	}
+}
+
+const indentStr = ">  "
+
+func fingerprint(obj interface{}) string {
+	c := spew.ConfigState{
+		SortKeys: true,
+		SpewKeys: true,
+	}
+	return c.Sprintf("%v", obj)
+}
+
+func dump(obj interface{}) string {
+	cfg := spew.ConfigState{
+		Indent: indentStr,
+	}
+	return cfg.Sdump(obj)
+}
+
+func indent(src []byte, prefix string) string {
+	var buf bytes.Buffer
+	json.Indent(&buf, src, prefix, indentStr)
+	return buf.String()
+}
+
+func BenchmarkStandardMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := json.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkStandardUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = json.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}
+
+func BenchmarkJSONIterMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := jsoniter.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkJSONIterUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = jsoniter.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}

--- a/output_tests/builtins/int32/types.go
+++ b/output_tests/builtins/int32/types.go
@@ -1,0 +1,3 @@
+package test
+
+type T int32

--- a/output_tests/builtins/int32_alias/json_test.go
+++ b/output_tests/builtins/int32_alias/json_test.go
@@ -1,0 +1,144 @@
+package test
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/davecgh/go-spew/spew"
+	fuzz "github.com/google/gofuzz"
+	jsoniter "github.com/json-iterator/go"
+)
+
+func Test_Roundtrip(t *testing.T) {
+	fz := fuzz.New().MaxDepth(10).NilChance(0.3)
+	for i := 0; i < 1000; i++ {
+		var before T
+		fz.Fuzz(&before)
+
+		jbStd, err := json.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with stdlib: %v", err)
+		}
+		jbIter, err := jsoniter.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with jsoniter: %v", err)
+		}
+		if string(jbStd) != string(jbIter) {
+			t.Errorf("marshal expected:\n    %s\ngot:\n    %s\nobj:\n    %s",
+				indent(jbStd, "    "), indent(jbIter, "    "), dump(before))
+		}
+
+		var afterStd T
+		err = json.Unmarshal(jbIter, &afterStd)
+		if err != nil {
+			t.Errorf("failed to unmarshal with stdlib: %v", err)
+		}
+		var afterIter T
+		err = jsoniter.Unmarshal(jbIter, &afterIter)
+		if err != nil {
+			t.Errorf("failed to unmarshal with jsoniter: %v", err)
+		}
+		if fingerprint(afterStd) != fingerprint(afterIter) {
+			t.Errorf("unmarshal expected:\n    %s\ngot:\n    %s\nvia:\n    %s",
+				dump(afterStd), dump(afterIter), indent(jbIter, "    "))
+		}
+	}
+}
+
+const indentStr = ">  "
+
+func fingerprint(obj interface{}) string {
+	c := spew.ConfigState{
+		SortKeys: true,
+		SpewKeys: true,
+	}
+	return c.Sprintf("%v", obj)
+}
+
+func dump(obj interface{}) string {
+	cfg := spew.ConfigState{
+		Indent: indentStr,
+	}
+	return cfg.Sdump(obj)
+}
+
+func indent(src []byte, prefix string) string {
+	var buf bytes.Buffer
+	json.Indent(&buf, src, prefix, indentStr)
+	return buf.String()
+}
+
+func BenchmarkStandardMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := json.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkStandardUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = json.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}
+
+func BenchmarkJSONIterMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := jsoniter.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkJSONIterUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = jsoniter.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}

--- a/output_tests/builtins/int32_alias/types.go
+++ b/output_tests/builtins/int32_alias/types.go
@@ -1,0 +1,3 @@
+package test
+
+type T int32

--- a/output_tests/builtins/int8/json_test.go
+++ b/output_tests/builtins/int8/json_test.go
@@ -1,0 +1,144 @@
+package test
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/davecgh/go-spew/spew"
+	fuzz "github.com/google/gofuzz"
+	jsoniter "github.com/json-iterator/go"
+)
+
+func Test_Roundtrip(t *testing.T) {
+	fz := fuzz.New().MaxDepth(10).NilChance(0.3)
+	for i := 0; i < 1000; i++ {
+		var before T
+		fz.Fuzz(&before)
+
+		jbStd, err := json.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with stdlib: %v", err)
+		}
+		jbIter, err := jsoniter.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with jsoniter: %v", err)
+		}
+		if string(jbStd) != string(jbIter) {
+			t.Errorf("marshal expected:\n    %s\ngot:\n    %s\nobj:\n    %s",
+				indent(jbStd, "    "), indent(jbIter, "    "), dump(before))
+		}
+
+		var afterStd T
+		err = json.Unmarshal(jbIter, &afterStd)
+		if err != nil {
+			t.Errorf("failed to unmarshal with stdlib: %v", err)
+		}
+		var afterIter T
+		err = jsoniter.Unmarshal(jbIter, &afterIter)
+		if err != nil {
+			t.Errorf("failed to unmarshal with jsoniter: %v", err)
+		}
+		if fingerprint(afterStd) != fingerprint(afterIter) {
+			t.Errorf("unmarshal expected:\n    %s\ngot:\n    %s\nvia:\n    %s",
+				dump(afterStd), dump(afterIter), indent(jbIter, "    "))
+		}
+	}
+}
+
+const indentStr = ">  "
+
+func fingerprint(obj interface{}) string {
+	c := spew.ConfigState{
+		SortKeys: true,
+		SpewKeys: true,
+	}
+	return c.Sprintf("%v", obj)
+}
+
+func dump(obj interface{}) string {
+	cfg := spew.ConfigState{
+		Indent: indentStr,
+	}
+	return cfg.Sdump(obj)
+}
+
+func indent(src []byte, prefix string) string {
+	var buf bytes.Buffer
+	json.Indent(&buf, src, prefix, indentStr)
+	return buf.String()
+}
+
+func BenchmarkStandardMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := json.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkStandardUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = json.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}
+
+func BenchmarkJSONIterMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := jsoniter.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkJSONIterUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = jsoniter.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}

--- a/output_tests/builtins/int8/types.go
+++ b/output_tests/builtins/int8/types.go
@@ -1,0 +1,3 @@
+package test
+
+type T int8

--- a/output_tests/builtins/int8_alias/json_test.go
+++ b/output_tests/builtins/int8_alias/json_test.go
@@ -1,0 +1,144 @@
+package test
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/davecgh/go-spew/spew"
+	fuzz "github.com/google/gofuzz"
+	jsoniter "github.com/json-iterator/go"
+)
+
+func Test_Roundtrip(t *testing.T) {
+	fz := fuzz.New().MaxDepth(10).NilChance(0.3)
+	for i := 0; i < 1000; i++ {
+		var before T
+		fz.Fuzz(&before)
+
+		jbStd, err := json.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with stdlib: %v", err)
+		}
+		jbIter, err := jsoniter.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with jsoniter: %v", err)
+		}
+		if string(jbStd) != string(jbIter) {
+			t.Errorf("marshal expected:\n    %s\ngot:\n    %s\nobj:\n    %s",
+				indent(jbStd, "    "), indent(jbIter, "    "), dump(before))
+		}
+
+		var afterStd T
+		err = json.Unmarshal(jbIter, &afterStd)
+		if err != nil {
+			t.Errorf("failed to unmarshal with stdlib: %v", err)
+		}
+		var afterIter T
+		err = jsoniter.Unmarshal(jbIter, &afterIter)
+		if err != nil {
+			t.Errorf("failed to unmarshal with jsoniter: %v", err)
+		}
+		if fingerprint(afterStd) != fingerprint(afterIter) {
+			t.Errorf("unmarshal expected:\n    %s\ngot:\n    %s\nvia:\n    %s",
+				dump(afterStd), dump(afterIter), indent(jbIter, "    "))
+		}
+	}
+}
+
+const indentStr = ">  "
+
+func fingerprint(obj interface{}) string {
+	c := spew.ConfigState{
+		SortKeys: true,
+		SpewKeys: true,
+	}
+	return c.Sprintf("%v", obj)
+}
+
+func dump(obj interface{}) string {
+	cfg := spew.ConfigState{
+		Indent: indentStr,
+	}
+	return cfg.Sdump(obj)
+}
+
+func indent(src []byte, prefix string) string {
+	var buf bytes.Buffer
+	json.Indent(&buf, src, prefix, indentStr)
+	return buf.String()
+}
+
+func BenchmarkStandardMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := json.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkStandardUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = json.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}
+
+func BenchmarkJSONIterMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := jsoniter.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkJSONIterUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = jsoniter.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}

--- a/output_tests/builtins/int8_alias/types.go
+++ b/output_tests/builtins/int8_alias/types.go
@@ -1,0 +1,3 @@
+package test
+
+type T int8

--- a/output_tests/builtins/string/json_test.go
+++ b/output_tests/builtins/string/json_test.go
@@ -1,0 +1,144 @@
+package test
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/davecgh/go-spew/spew"
+	fuzz "github.com/google/gofuzz"
+	jsoniter "github.com/json-iterator/go"
+)
+
+func Test_Roundtrip(t *testing.T) {
+	fz := fuzz.New().MaxDepth(10).NilChance(0.3)
+	for i := 0; i < 1000; i++ {
+		var before T
+		fz.Fuzz(&before)
+
+		jbStd, err := json.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with stdlib: %v", err)
+		}
+		jbIter, err := jsoniter.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with jsoniter: %v", err)
+		}
+		if string(jbStd) != string(jbIter) {
+			t.Errorf("marshal expected:\n    %s\ngot:\n    %s\nobj:\n    %s",
+				indent(jbStd, "    "), indent(jbIter, "    "), dump(before))
+		}
+
+		var afterStd T
+		err = json.Unmarshal(jbIter, &afterStd)
+		if err != nil {
+			t.Errorf("failed to unmarshal with stdlib: %v", err)
+		}
+		var afterIter T
+		err = jsoniter.Unmarshal(jbIter, &afterIter)
+		if err != nil {
+			t.Errorf("failed to unmarshal with jsoniter: %v", err)
+		}
+		if fingerprint(afterStd) != fingerprint(afterIter) {
+			t.Errorf("unmarshal expected:\n    %s\ngot:\n    %s\nvia:\n    %s",
+				dump(afterStd), dump(afterIter), indent(jbIter, "    "))
+		}
+	}
+}
+
+const indentStr = ">  "
+
+func fingerprint(obj interface{}) string {
+	c := spew.ConfigState{
+		SortKeys: true,
+		SpewKeys: true,
+	}
+	return c.Sprintf("%v", obj)
+}
+
+func dump(obj interface{}) string {
+	cfg := spew.ConfigState{
+		Indent: indentStr,
+	}
+	return cfg.Sdump(obj)
+}
+
+func indent(src []byte, prefix string) string {
+	var buf bytes.Buffer
+	json.Indent(&buf, src, prefix, indentStr)
+	return buf.String()
+}
+
+func BenchmarkStandardMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := json.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkStandardUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = json.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}
+
+func BenchmarkJSONIterMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := jsoniter.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkJSONIterUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = jsoniter.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}

--- a/output_tests/builtins/string/types.go
+++ b/output_tests/builtins/string/types.go
@@ -1,0 +1,3 @@
+package test
+
+type T string

--- a/output_tests/builtins/string_alias/json_test.go
+++ b/output_tests/builtins/string_alias/json_test.go
@@ -1,0 +1,144 @@
+package test
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/davecgh/go-spew/spew"
+	fuzz "github.com/google/gofuzz"
+	jsoniter "github.com/json-iterator/go"
+)
+
+func Test_Roundtrip(t *testing.T) {
+	fz := fuzz.New().MaxDepth(10).NilChance(0.3)
+	for i := 0; i < 1000; i++ {
+		var before T
+		fz.Fuzz(&before)
+
+		jbStd, err := json.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with stdlib: %v", err)
+		}
+		jbIter, err := jsoniter.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with jsoniter: %v", err)
+		}
+		if string(jbStd) != string(jbIter) {
+			t.Errorf("marshal expected:\n    %s\ngot:\n    %s\nobj:\n    %s",
+				indent(jbStd, "    "), indent(jbIter, "    "), dump(before))
+		}
+
+		var afterStd T
+		err = json.Unmarshal(jbIter, &afterStd)
+		if err != nil {
+			t.Errorf("failed to unmarshal with stdlib: %v", err)
+		}
+		var afterIter T
+		err = jsoniter.Unmarshal(jbIter, &afterIter)
+		if err != nil {
+			t.Errorf("failed to unmarshal with jsoniter: %v", err)
+		}
+		if fingerprint(afterStd) != fingerprint(afterIter) {
+			t.Errorf("unmarshal expected:\n    %s\ngot:\n    %s\nvia:\n    %s",
+				dump(afterStd), dump(afterIter), indent(jbIter, "    "))
+		}
+	}
+}
+
+const indentStr = ">  "
+
+func fingerprint(obj interface{}) string {
+	c := spew.ConfigState{
+		SortKeys: true,
+		SpewKeys: true,
+	}
+	return c.Sprintf("%v", obj)
+}
+
+func dump(obj interface{}) string {
+	cfg := spew.ConfigState{
+		Indent: indentStr,
+	}
+	return cfg.Sdump(obj)
+}
+
+func indent(src []byte, prefix string) string {
+	var buf bytes.Buffer
+	json.Indent(&buf, src, prefix, indentStr)
+	return buf.String()
+}
+
+func BenchmarkStandardMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := json.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkStandardUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = json.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}
+
+func BenchmarkJSONIterMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := jsoniter.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkJSONIterUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = jsoniter.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}

--- a/output_tests/builtins/string_alias/types.go
+++ b/output_tests/builtins/string_alias/types.go
@@ -1,0 +1,3 @@
+package test
+
+type T string

--- a/output_tests/builtins/uint16/json_test.go
+++ b/output_tests/builtins/uint16/json_test.go
@@ -1,0 +1,144 @@
+package test
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/davecgh/go-spew/spew"
+	fuzz "github.com/google/gofuzz"
+	jsoniter "github.com/json-iterator/go"
+)
+
+func Test_Roundtrip(t *testing.T) {
+	fz := fuzz.New().MaxDepth(10).NilChance(0.3)
+	for i := 0; i < 1000; i++ {
+		var before T
+		fz.Fuzz(&before)
+
+		jbStd, err := json.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with stdlib: %v", err)
+		}
+		jbIter, err := jsoniter.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with jsoniter: %v", err)
+		}
+		if string(jbStd) != string(jbIter) {
+			t.Errorf("marshal expected:\n    %s\ngot:\n    %s\nobj:\n    %s",
+				indent(jbStd, "    "), indent(jbIter, "    "), dump(before))
+		}
+
+		var afterStd T
+		err = json.Unmarshal(jbIter, &afterStd)
+		if err != nil {
+			t.Errorf("failed to unmarshal with stdlib: %v", err)
+		}
+		var afterIter T
+		err = jsoniter.Unmarshal(jbIter, &afterIter)
+		if err != nil {
+			t.Errorf("failed to unmarshal with jsoniter: %v", err)
+		}
+		if fingerprint(afterStd) != fingerprint(afterIter) {
+			t.Errorf("unmarshal expected:\n    %s\ngot:\n    %s\nvia:\n    %s",
+				dump(afterStd), dump(afterIter), indent(jbIter, "    "))
+		}
+	}
+}
+
+const indentStr = ">  "
+
+func fingerprint(obj interface{}) string {
+	c := spew.ConfigState{
+		SortKeys: true,
+		SpewKeys: true,
+	}
+	return c.Sprintf("%v", obj)
+}
+
+func dump(obj interface{}) string {
+	cfg := spew.ConfigState{
+		Indent: indentStr,
+	}
+	return cfg.Sdump(obj)
+}
+
+func indent(src []byte, prefix string) string {
+	var buf bytes.Buffer
+	json.Indent(&buf, src, prefix, indentStr)
+	return buf.String()
+}
+
+func BenchmarkStandardMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := json.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkStandardUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = json.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}
+
+func BenchmarkJSONIterMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := jsoniter.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkJSONIterUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = jsoniter.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}

--- a/output_tests/builtins/uint16/types.go
+++ b/output_tests/builtins/uint16/types.go
@@ -1,0 +1,3 @@
+package test
+
+type T uint16

--- a/output_tests/builtins/uint16_alias/json_test.go
+++ b/output_tests/builtins/uint16_alias/json_test.go
@@ -1,0 +1,144 @@
+package test
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/davecgh/go-spew/spew"
+	fuzz "github.com/google/gofuzz"
+	jsoniter "github.com/json-iterator/go"
+)
+
+func Test_Roundtrip(t *testing.T) {
+	fz := fuzz.New().MaxDepth(10).NilChance(0.3)
+	for i := 0; i < 1000; i++ {
+		var before T
+		fz.Fuzz(&before)
+
+		jbStd, err := json.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with stdlib: %v", err)
+		}
+		jbIter, err := jsoniter.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with jsoniter: %v", err)
+		}
+		if string(jbStd) != string(jbIter) {
+			t.Errorf("marshal expected:\n    %s\ngot:\n    %s\nobj:\n    %s",
+				indent(jbStd, "    "), indent(jbIter, "    "), dump(before))
+		}
+
+		var afterStd T
+		err = json.Unmarshal(jbIter, &afterStd)
+		if err != nil {
+			t.Errorf("failed to unmarshal with stdlib: %v", err)
+		}
+		var afterIter T
+		err = jsoniter.Unmarshal(jbIter, &afterIter)
+		if err != nil {
+			t.Errorf("failed to unmarshal with jsoniter: %v", err)
+		}
+		if fingerprint(afterStd) != fingerprint(afterIter) {
+			t.Errorf("unmarshal expected:\n    %s\ngot:\n    %s\nvia:\n    %s",
+				dump(afterStd), dump(afterIter), indent(jbIter, "    "))
+		}
+	}
+}
+
+const indentStr = ">  "
+
+func fingerprint(obj interface{}) string {
+	c := spew.ConfigState{
+		SortKeys: true,
+		SpewKeys: true,
+	}
+	return c.Sprintf("%v", obj)
+}
+
+func dump(obj interface{}) string {
+	cfg := spew.ConfigState{
+		Indent: indentStr,
+	}
+	return cfg.Sdump(obj)
+}
+
+func indent(src []byte, prefix string) string {
+	var buf bytes.Buffer
+	json.Indent(&buf, src, prefix, indentStr)
+	return buf.String()
+}
+
+func BenchmarkStandardMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := json.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkStandardUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = json.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}
+
+func BenchmarkJSONIterMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := jsoniter.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkJSONIterUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = jsoniter.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}

--- a/output_tests/builtins/uint16_alias/types.go
+++ b/output_tests/builtins/uint16_alias/types.go
@@ -1,0 +1,3 @@
+package test
+
+type T uint16

--- a/output_tests/builtins/uint32/json_test.go
+++ b/output_tests/builtins/uint32/json_test.go
@@ -1,0 +1,144 @@
+package test
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/davecgh/go-spew/spew"
+	fuzz "github.com/google/gofuzz"
+	jsoniter "github.com/json-iterator/go"
+)
+
+func Test_Roundtrip(t *testing.T) {
+	fz := fuzz.New().MaxDepth(10).NilChance(0.3)
+	for i := 0; i < 1000; i++ {
+		var before T
+		fz.Fuzz(&before)
+
+		jbStd, err := json.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with stdlib: %v", err)
+		}
+		jbIter, err := jsoniter.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with jsoniter: %v", err)
+		}
+		if string(jbStd) != string(jbIter) {
+			t.Errorf("marshal expected:\n    %s\ngot:\n    %s\nobj:\n    %s",
+				indent(jbStd, "    "), indent(jbIter, "    "), dump(before))
+		}
+
+		var afterStd T
+		err = json.Unmarshal(jbIter, &afterStd)
+		if err != nil {
+			t.Errorf("failed to unmarshal with stdlib: %v", err)
+		}
+		var afterIter T
+		err = jsoniter.Unmarshal(jbIter, &afterIter)
+		if err != nil {
+			t.Errorf("failed to unmarshal with jsoniter: %v", err)
+		}
+		if fingerprint(afterStd) != fingerprint(afterIter) {
+			t.Errorf("unmarshal expected:\n    %s\ngot:\n    %s\nvia:\n    %s",
+				dump(afterStd), dump(afterIter), indent(jbIter, "    "))
+		}
+	}
+}
+
+const indentStr = ">  "
+
+func fingerprint(obj interface{}) string {
+	c := spew.ConfigState{
+		SortKeys: true,
+		SpewKeys: true,
+	}
+	return c.Sprintf("%v", obj)
+}
+
+func dump(obj interface{}) string {
+	cfg := spew.ConfigState{
+		Indent: indentStr,
+	}
+	return cfg.Sdump(obj)
+}
+
+func indent(src []byte, prefix string) string {
+	var buf bytes.Buffer
+	json.Indent(&buf, src, prefix, indentStr)
+	return buf.String()
+}
+
+func BenchmarkStandardMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := json.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkStandardUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = json.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}
+
+func BenchmarkJSONIterMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := jsoniter.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkJSONIterUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = jsoniter.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}

--- a/output_tests/builtins/uint32/types.go
+++ b/output_tests/builtins/uint32/types.go
@@ -1,0 +1,3 @@
+package test
+
+type T uint32

--- a/output_tests/builtins/uint32_alias/json_test.go
+++ b/output_tests/builtins/uint32_alias/json_test.go
@@ -1,0 +1,144 @@
+package test
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/davecgh/go-spew/spew"
+	fuzz "github.com/google/gofuzz"
+	jsoniter "github.com/json-iterator/go"
+)
+
+func Test_Roundtrip(t *testing.T) {
+	fz := fuzz.New().MaxDepth(10).NilChance(0.3)
+	for i := 0; i < 1000; i++ {
+		var before T
+		fz.Fuzz(&before)
+
+		jbStd, err := json.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with stdlib: %v", err)
+		}
+		jbIter, err := jsoniter.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with jsoniter: %v", err)
+		}
+		if string(jbStd) != string(jbIter) {
+			t.Errorf("marshal expected:\n    %s\ngot:\n    %s\nobj:\n    %s",
+				indent(jbStd, "    "), indent(jbIter, "    "), dump(before))
+		}
+
+		var afterStd T
+		err = json.Unmarshal(jbIter, &afterStd)
+		if err != nil {
+			t.Errorf("failed to unmarshal with stdlib: %v", err)
+		}
+		var afterIter T
+		err = jsoniter.Unmarshal(jbIter, &afterIter)
+		if err != nil {
+			t.Errorf("failed to unmarshal with jsoniter: %v", err)
+		}
+		if fingerprint(afterStd) != fingerprint(afterIter) {
+			t.Errorf("unmarshal expected:\n    %s\ngot:\n    %s\nvia:\n    %s",
+				dump(afterStd), dump(afterIter), indent(jbIter, "    "))
+		}
+	}
+}
+
+const indentStr = ">  "
+
+func fingerprint(obj interface{}) string {
+	c := spew.ConfigState{
+		SortKeys: true,
+		SpewKeys: true,
+	}
+	return c.Sprintf("%v", obj)
+}
+
+func dump(obj interface{}) string {
+	cfg := spew.ConfigState{
+		Indent: indentStr,
+	}
+	return cfg.Sdump(obj)
+}
+
+func indent(src []byte, prefix string) string {
+	var buf bytes.Buffer
+	json.Indent(&buf, src, prefix, indentStr)
+	return buf.String()
+}
+
+func BenchmarkStandardMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := json.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkStandardUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = json.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}
+
+func BenchmarkJSONIterMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := jsoniter.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkJSONIterUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = jsoniter.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}

--- a/output_tests/builtins/uint32_alias/types.go
+++ b/output_tests/builtins/uint32_alias/types.go
@@ -1,0 +1,3 @@
+package test
+
+type T uint32

--- a/output_tests/builtins/uint8/json_test.go
+++ b/output_tests/builtins/uint8/json_test.go
@@ -1,0 +1,144 @@
+package test
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/davecgh/go-spew/spew"
+	fuzz "github.com/google/gofuzz"
+	jsoniter "github.com/json-iterator/go"
+)
+
+func Test_Roundtrip(t *testing.T) {
+	fz := fuzz.New().MaxDepth(10).NilChance(0.3)
+	for i := 0; i < 1000; i++ {
+		var before T
+		fz.Fuzz(&before)
+
+		jbStd, err := json.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with stdlib: %v", err)
+		}
+		jbIter, err := jsoniter.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with jsoniter: %v", err)
+		}
+		if string(jbStd) != string(jbIter) {
+			t.Errorf("marshal expected:\n    %s\ngot:\n    %s\nobj:\n    %s",
+				indent(jbStd, "    "), indent(jbIter, "    "), dump(before))
+		}
+
+		var afterStd T
+		err = json.Unmarshal(jbIter, &afterStd)
+		if err != nil {
+			t.Errorf("failed to unmarshal with stdlib: %v", err)
+		}
+		var afterIter T
+		err = jsoniter.Unmarshal(jbIter, &afterIter)
+		if err != nil {
+			t.Errorf("failed to unmarshal with jsoniter: %v", err)
+		}
+		if fingerprint(afterStd) != fingerprint(afterIter) {
+			t.Errorf("unmarshal expected:\n    %s\ngot:\n    %s\nvia:\n    %s",
+				dump(afterStd), dump(afterIter), indent(jbIter, "    "))
+		}
+	}
+}
+
+const indentStr = ">  "
+
+func fingerprint(obj interface{}) string {
+	c := spew.ConfigState{
+		SortKeys: true,
+		SpewKeys: true,
+	}
+	return c.Sprintf("%v", obj)
+}
+
+func dump(obj interface{}) string {
+	cfg := spew.ConfigState{
+		Indent: indentStr,
+	}
+	return cfg.Sdump(obj)
+}
+
+func indent(src []byte, prefix string) string {
+	var buf bytes.Buffer
+	json.Indent(&buf, src, prefix, indentStr)
+	return buf.String()
+}
+
+func BenchmarkStandardMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := json.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkStandardUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = json.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}
+
+func BenchmarkJSONIterMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := jsoniter.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkJSONIterUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = jsoniter.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}

--- a/output_tests/builtins/uint8/types.go
+++ b/output_tests/builtins/uint8/types.go
@@ -1,0 +1,3 @@
+package test
+
+type T uint8

--- a/output_tests/builtins/uint8_alias/json_test.go
+++ b/output_tests/builtins/uint8_alias/json_test.go
@@ -1,0 +1,144 @@
+package test
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/davecgh/go-spew/spew"
+	fuzz "github.com/google/gofuzz"
+	jsoniter "github.com/json-iterator/go"
+)
+
+func Test_Roundtrip(t *testing.T) {
+	fz := fuzz.New().MaxDepth(10).NilChance(0.3)
+	for i := 0; i < 1000; i++ {
+		var before T
+		fz.Fuzz(&before)
+
+		jbStd, err := json.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with stdlib: %v", err)
+		}
+		jbIter, err := jsoniter.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with jsoniter: %v", err)
+		}
+		if string(jbStd) != string(jbIter) {
+			t.Errorf("marshal expected:\n    %s\ngot:\n    %s\nobj:\n    %s",
+				indent(jbStd, "    "), indent(jbIter, "    "), dump(before))
+		}
+
+		var afterStd T
+		err = json.Unmarshal(jbIter, &afterStd)
+		if err != nil {
+			t.Errorf("failed to unmarshal with stdlib: %v", err)
+		}
+		var afterIter T
+		err = jsoniter.Unmarshal(jbIter, &afterIter)
+		if err != nil {
+			t.Errorf("failed to unmarshal with jsoniter: %v", err)
+		}
+		if fingerprint(afterStd) != fingerprint(afterIter) {
+			t.Errorf("unmarshal expected:\n    %s\ngot:\n    %s\nvia:\n    %s",
+				dump(afterStd), dump(afterIter), indent(jbIter, "    "))
+		}
+	}
+}
+
+const indentStr = ">  "
+
+func fingerprint(obj interface{}) string {
+	c := spew.ConfigState{
+		SortKeys: true,
+		SpewKeys: true,
+	}
+	return c.Sprintf("%v", obj)
+}
+
+func dump(obj interface{}) string {
+	cfg := spew.ConfigState{
+		Indent: indentStr,
+	}
+	return cfg.Sdump(obj)
+}
+
+func indent(src []byte, prefix string) string {
+	var buf bytes.Buffer
+	json.Indent(&buf, src, prefix, indentStr)
+	return buf.String()
+}
+
+func BenchmarkStandardMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := json.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkStandardUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = json.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}
+
+func BenchmarkJSONIterMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := jsoniter.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkJSONIterUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = jsoniter.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}

--- a/output_tests/builtins/uint8_alias/types.go
+++ b/output_tests/builtins/uint8_alias/types.go
@@ -1,0 +1,3 @@
+package test
+
+type T uint8

--- a/output_tests/maps/builtins/int32/bool/json_test.go
+++ b/output_tests/maps/builtins/int32/bool/json_test.go
@@ -1,0 +1,144 @@
+package test
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/davecgh/go-spew/spew"
+	fuzz "github.com/google/gofuzz"
+	jsoniter "github.com/json-iterator/go"
+)
+
+func Test_Roundtrip(t *testing.T) {
+	fz := fuzz.New().MaxDepth(10).NilChance(0.3)
+	for i := 0; i < 1000; i++ {
+		var before T
+		fz.Fuzz(&before)
+
+		jbStd, err := json.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with stdlib: %v", err)
+		}
+		jbIter, err := jsoniter.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with jsoniter: %v", err)
+		}
+		if string(jbStd) != string(jbIter) {
+			t.Errorf("marshal expected:\n    %s\ngot:\n    %s\nobj:\n    %s",
+				indent(jbStd, "    "), indent(jbIter, "    "), dump(before))
+		}
+
+		var afterStd T
+		err = json.Unmarshal(jbIter, &afterStd)
+		if err != nil {
+			t.Errorf("failed to unmarshal with stdlib: %v", err)
+		}
+		var afterIter T
+		err = jsoniter.Unmarshal(jbIter, &afterIter)
+		if err != nil {
+			t.Errorf("failed to unmarshal with jsoniter: %v", err)
+		}
+		if fingerprint(afterStd) != fingerprint(afterIter) {
+			t.Errorf("unmarshal expected:\n    %s\ngot:\n    %s\nvia:\n    %s",
+				dump(afterStd), dump(afterIter), indent(jbIter, "    "))
+		}
+	}
+}
+
+const indentStr = ">  "
+
+func fingerprint(obj interface{}) string {
+	c := spew.ConfigState{
+		SortKeys: true,
+		SpewKeys: true,
+	}
+	return c.Sprintf("%v", obj)
+}
+
+func dump(obj interface{}) string {
+	cfg := spew.ConfigState{
+		Indent: indentStr,
+	}
+	return cfg.Sdump(obj)
+}
+
+func indent(src []byte, prefix string) string {
+	var buf bytes.Buffer
+	json.Indent(&buf, src, prefix, indentStr)
+	return buf.String()
+}
+
+func BenchmarkStandardMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := json.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkStandardUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = json.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}
+
+func BenchmarkJSONIterMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := jsoniter.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkJSONIterUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = jsoniter.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}

--- a/output_tests/maps/builtins/int32/bool/types.go
+++ b/output_tests/maps/builtins/int32/bool/types.go
@@ -1,0 +1,3 @@
+package test
+
+type T map[int32]bool

--- a/output_tests/maps/builtins/int32/byte/json_test.go
+++ b/output_tests/maps/builtins/int32/byte/json_test.go
@@ -1,0 +1,144 @@
+package test
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/davecgh/go-spew/spew"
+	fuzz "github.com/google/gofuzz"
+	jsoniter "github.com/json-iterator/go"
+)
+
+func Test_Roundtrip(t *testing.T) {
+	fz := fuzz.New().MaxDepth(10).NilChance(0.3)
+	for i := 0; i < 1000; i++ {
+		var before T
+		fz.Fuzz(&before)
+
+		jbStd, err := json.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with stdlib: %v", err)
+		}
+		jbIter, err := jsoniter.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with jsoniter: %v", err)
+		}
+		if string(jbStd) != string(jbIter) {
+			t.Errorf("marshal expected:\n    %s\ngot:\n    %s\nobj:\n    %s",
+				indent(jbStd, "    "), indent(jbIter, "    "), dump(before))
+		}
+
+		var afterStd T
+		err = json.Unmarshal(jbIter, &afterStd)
+		if err != nil {
+			t.Errorf("failed to unmarshal with stdlib: %v", err)
+		}
+		var afterIter T
+		err = jsoniter.Unmarshal(jbIter, &afterIter)
+		if err != nil {
+			t.Errorf("failed to unmarshal with jsoniter: %v", err)
+		}
+		if fingerprint(afterStd) != fingerprint(afterIter) {
+			t.Errorf("unmarshal expected:\n    %s\ngot:\n    %s\nvia:\n    %s",
+				dump(afterStd), dump(afterIter), indent(jbIter, "    "))
+		}
+	}
+}
+
+const indentStr = ">  "
+
+func fingerprint(obj interface{}) string {
+	c := spew.ConfigState{
+		SortKeys: true,
+		SpewKeys: true,
+	}
+	return c.Sprintf("%v", obj)
+}
+
+func dump(obj interface{}) string {
+	cfg := spew.ConfigState{
+		Indent: indentStr,
+	}
+	return cfg.Sdump(obj)
+}
+
+func indent(src []byte, prefix string) string {
+	var buf bytes.Buffer
+	json.Indent(&buf, src, prefix, indentStr)
+	return buf.String()
+}
+
+func BenchmarkStandardMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := json.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkStandardUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = json.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}
+
+func BenchmarkJSONIterMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := jsoniter.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkJSONIterUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = jsoniter.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}

--- a/output_tests/maps/builtins/int32/byte/types.go
+++ b/output_tests/maps/builtins/int32/byte/types.go
@@ -1,0 +1,3 @@
+package test
+
+type T map[int32]byte

--- a/output_tests/maps/builtins/int32/float32/json_test.go
+++ b/output_tests/maps/builtins/int32/float32/json_test.go
@@ -1,0 +1,144 @@
+package test
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/davecgh/go-spew/spew"
+	fuzz "github.com/google/gofuzz"
+	jsoniter "github.com/json-iterator/go"
+)
+
+func Test_Roundtrip(t *testing.T) {
+	fz := fuzz.New().MaxDepth(10).NilChance(0.3)
+	for i := 0; i < 1000; i++ {
+		var before T
+		fz.Fuzz(&before)
+
+		jbStd, err := json.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with stdlib: %v", err)
+		}
+		jbIter, err := jsoniter.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with jsoniter: %v", err)
+		}
+		if string(jbStd) != string(jbIter) {
+			t.Errorf("marshal expected:\n    %s\ngot:\n    %s\nobj:\n    %s",
+				indent(jbStd, "    "), indent(jbIter, "    "), dump(before))
+		}
+
+		var afterStd T
+		err = json.Unmarshal(jbIter, &afterStd)
+		if err != nil {
+			t.Errorf("failed to unmarshal with stdlib: %v", err)
+		}
+		var afterIter T
+		err = jsoniter.Unmarshal(jbIter, &afterIter)
+		if err != nil {
+			t.Errorf("failed to unmarshal with jsoniter: %v", err)
+		}
+		if fingerprint(afterStd) != fingerprint(afterIter) {
+			t.Errorf("unmarshal expected:\n    %s\ngot:\n    %s\nvia:\n    %s",
+				dump(afterStd), dump(afterIter), indent(jbIter, "    "))
+		}
+	}
+}
+
+const indentStr = ">  "
+
+func fingerprint(obj interface{}) string {
+	c := spew.ConfigState{
+		SortKeys: true,
+		SpewKeys: true,
+	}
+	return c.Sprintf("%v", obj)
+}
+
+func dump(obj interface{}) string {
+	cfg := spew.ConfigState{
+		Indent: indentStr,
+	}
+	return cfg.Sdump(obj)
+}
+
+func indent(src []byte, prefix string) string {
+	var buf bytes.Buffer
+	json.Indent(&buf, src, prefix, indentStr)
+	return buf.String()
+}
+
+func BenchmarkStandardMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := json.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkStandardUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = json.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}
+
+func BenchmarkJSONIterMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := jsoniter.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkJSONIterUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = jsoniter.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}

--- a/output_tests/maps/builtins/int32/float32/types.go
+++ b/output_tests/maps/builtins/int32/float32/types.go
@@ -1,0 +1,3 @@
+package test
+
+type T map[int32]float32

--- a/output_tests/maps/builtins/int32/float64/json_test.go
+++ b/output_tests/maps/builtins/int32/float64/json_test.go
@@ -1,0 +1,144 @@
+package test
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/davecgh/go-spew/spew"
+	fuzz "github.com/google/gofuzz"
+	jsoniter "github.com/json-iterator/go"
+)
+
+func Test_Roundtrip(t *testing.T) {
+	fz := fuzz.New().MaxDepth(10).NilChance(0.3)
+	for i := 0; i < 1000; i++ {
+		var before T
+		fz.Fuzz(&before)
+
+		jbStd, err := json.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with stdlib: %v", err)
+		}
+		jbIter, err := jsoniter.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with jsoniter: %v", err)
+		}
+		if string(jbStd) != string(jbIter) {
+			t.Errorf("marshal expected:\n    %s\ngot:\n    %s\nobj:\n    %s",
+				indent(jbStd, "    "), indent(jbIter, "    "), dump(before))
+		}
+
+		var afterStd T
+		err = json.Unmarshal(jbIter, &afterStd)
+		if err != nil {
+			t.Errorf("failed to unmarshal with stdlib: %v", err)
+		}
+		var afterIter T
+		err = jsoniter.Unmarshal(jbIter, &afterIter)
+		if err != nil {
+			t.Errorf("failed to unmarshal with jsoniter: %v", err)
+		}
+		if fingerprint(afterStd) != fingerprint(afterIter) {
+			t.Errorf("unmarshal expected:\n    %s\ngot:\n    %s\nvia:\n    %s",
+				dump(afterStd), dump(afterIter), indent(jbIter, "    "))
+		}
+	}
+}
+
+const indentStr = ">  "
+
+func fingerprint(obj interface{}) string {
+	c := spew.ConfigState{
+		SortKeys: true,
+		SpewKeys: true,
+	}
+	return c.Sprintf("%v", obj)
+}
+
+func dump(obj interface{}) string {
+	cfg := spew.ConfigState{
+		Indent: indentStr,
+	}
+	return cfg.Sdump(obj)
+}
+
+func indent(src []byte, prefix string) string {
+	var buf bytes.Buffer
+	json.Indent(&buf, src, prefix, indentStr)
+	return buf.String()
+}
+
+func BenchmarkStandardMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := json.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkStandardUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = json.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}
+
+func BenchmarkJSONIterMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := jsoniter.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkJSONIterUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = jsoniter.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}

--- a/output_tests/maps/builtins/int32/float64/types.go
+++ b/output_tests/maps/builtins/int32/float64/types.go
@@ -1,0 +1,3 @@
+package test
+
+type T map[int32]float64

--- a/output_tests/maps/builtins/int32/int32/json_test.go
+++ b/output_tests/maps/builtins/int32/int32/json_test.go
@@ -1,0 +1,144 @@
+package test
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/davecgh/go-spew/spew"
+	fuzz "github.com/google/gofuzz"
+	jsoniter "github.com/json-iterator/go"
+)
+
+func Test_Roundtrip(t *testing.T) {
+	fz := fuzz.New().MaxDepth(10).NilChance(0.3)
+	for i := 0; i < 1000; i++ {
+		var before T
+		fz.Fuzz(&before)
+
+		jbStd, err := json.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with stdlib: %v", err)
+		}
+		jbIter, err := jsoniter.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with jsoniter: %v", err)
+		}
+		if string(jbStd) != string(jbIter) {
+			t.Errorf("marshal expected:\n    %s\ngot:\n    %s\nobj:\n    %s",
+				indent(jbStd, "    "), indent(jbIter, "    "), dump(before))
+		}
+
+		var afterStd T
+		err = json.Unmarshal(jbIter, &afterStd)
+		if err != nil {
+			t.Errorf("failed to unmarshal with stdlib: %v", err)
+		}
+		var afterIter T
+		err = jsoniter.Unmarshal(jbIter, &afterIter)
+		if err != nil {
+			t.Errorf("failed to unmarshal with jsoniter: %v", err)
+		}
+		if fingerprint(afterStd) != fingerprint(afterIter) {
+			t.Errorf("unmarshal expected:\n    %s\ngot:\n    %s\nvia:\n    %s",
+				dump(afterStd), dump(afterIter), indent(jbIter, "    "))
+		}
+	}
+}
+
+const indentStr = ">  "
+
+func fingerprint(obj interface{}) string {
+	c := spew.ConfigState{
+		SortKeys: true,
+		SpewKeys: true,
+	}
+	return c.Sprintf("%v", obj)
+}
+
+func dump(obj interface{}) string {
+	cfg := spew.ConfigState{
+		Indent: indentStr,
+	}
+	return cfg.Sdump(obj)
+}
+
+func indent(src []byte, prefix string) string {
+	var buf bytes.Buffer
+	json.Indent(&buf, src, prefix, indentStr)
+	return buf.String()
+}
+
+func BenchmarkStandardMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := json.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkStandardUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = json.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}
+
+func BenchmarkJSONIterMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := jsoniter.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkJSONIterUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = jsoniter.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}

--- a/output_tests/maps/builtins/int32/int32/types.go
+++ b/output_tests/maps/builtins/int32/int32/types.go
@@ -1,0 +1,3 @@
+package test
+
+type T map[int32]int32

--- a/output_tests/maps/builtins/int32/int8/json_test.go
+++ b/output_tests/maps/builtins/int32/int8/json_test.go
@@ -1,0 +1,144 @@
+package test
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/davecgh/go-spew/spew"
+	fuzz "github.com/google/gofuzz"
+	jsoniter "github.com/json-iterator/go"
+)
+
+func Test_Roundtrip(t *testing.T) {
+	fz := fuzz.New().MaxDepth(10).NilChance(0.3)
+	for i := 0; i < 1000; i++ {
+		var before T
+		fz.Fuzz(&before)
+
+		jbStd, err := json.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with stdlib: %v", err)
+		}
+		jbIter, err := jsoniter.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with jsoniter: %v", err)
+		}
+		if string(jbStd) != string(jbIter) {
+			t.Errorf("marshal expected:\n    %s\ngot:\n    %s\nobj:\n    %s",
+				indent(jbStd, "    "), indent(jbIter, "    "), dump(before))
+		}
+
+		var afterStd T
+		err = json.Unmarshal(jbIter, &afterStd)
+		if err != nil {
+			t.Errorf("failed to unmarshal with stdlib: %v", err)
+		}
+		var afterIter T
+		err = jsoniter.Unmarshal(jbIter, &afterIter)
+		if err != nil {
+			t.Errorf("failed to unmarshal with jsoniter: %v", err)
+		}
+		if fingerprint(afterStd) != fingerprint(afterIter) {
+			t.Errorf("unmarshal expected:\n    %s\ngot:\n    %s\nvia:\n    %s",
+				dump(afterStd), dump(afterIter), indent(jbIter, "    "))
+		}
+	}
+}
+
+const indentStr = ">  "
+
+func fingerprint(obj interface{}) string {
+	c := spew.ConfigState{
+		SortKeys: true,
+		SpewKeys: true,
+	}
+	return c.Sprintf("%v", obj)
+}
+
+func dump(obj interface{}) string {
+	cfg := spew.ConfigState{
+		Indent: indentStr,
+	}
+	return cfg.Sdump(obj)
+}
+
+func indent(src []byte, prefix string) string {
+	var buf bytes.Buffer
+	json.Indent(&buf, src, prefix, indentStr)
+	return buf.String()
+}
+
+func BenchmarkStandardMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := json.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkStandardUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = json.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}
+
+func BenchmarkJSONIterMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := jsoniter.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkJSONIterUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = jsoniter.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}

--- a/output_tests/maps/builtins/int32/int8/types.go
+++ b/output_tests/maps/builtins/int32/int8/types.go
@@ -1,0 +1,3 @@
+package test
+
+type T map[int32]int8

--- a/output_tests/maps/builtins/int32/string/json_test.go
+++ b/output_tests/maps/builtins/int32/string/json_test.go
@@ -1,0 +1,144 @@
+package test
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/davecgh/go-spew/spew"
+	fuzz "github.com/google/gofuzz"
+	jsoniter "github.com/json-iterator/go"
+)
+
+func Test_Roundtrip(t *testing.T) {
+	fz := fuzz.New().MaxDepth(10).NilChance(0.3)
+	for i := 0; i < 1000; i++ {
+		var before T
+		fz.Fuzz(&before)
+
+		jbStd, err := json.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with stdlib: %v", err)
+		}
+		jbIter, err := jsoniter.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with jsoniter: %v", err)
+		}
+		if string(jbStd) != string(jbIter) {
+			t.Errorf("marshal expected:\n    %s\ngot:\n    %s\nobj:\n    %s",
+				indent(jbStd, "    "), indent(jbIter, "    "), dump(before))
+		}
+
+		var afterStd T
+		err = json.Unmarshal(jbIter, &afterStd)
+		if err != nil {
+			t.Errorf("failed to unmarshal with stdlib: %v", err)
+		}
+		var afterIter T
+		err = jsoniter.Unmarshal(jbIter, &afterIter)
+		if err != nil {
+			t.Errorf("failed to unmarshal with jsoniter: %v", err)
+		}
+		if fingerprint(afterStd) != fingerprint(afterIter) {
+			t.Errorf("unmarshal expected:\n    %s\ngot:\n    %s\nvia:\n    %s",
+				dump(afterStd), dump(afterIter), indent(jbIter, "    "))
+		}
+	}
+}
+
+const indentStr = ">  "
+
+func fingerprint(obj interface{}) string {
+	c := spew.ConfigState{
+		SortKeys: true,
+		SpewKeys: true,
+	}
+	return c.Sprintf("%v", obj)
+}
+
+func dump(obj interface{}) string {
+	cfg := spew.ConfigState{
+		Indent: indentStr,
+	}
+	return cfg.Sdump(obj)
+}
+
+func indent(src []byte, prefix string) string {
+	var buf bytes.Buffer
+	json.Indent(&buf, src, prefix, indentStr)
+	return buf.String()
+}
+
+func BenchmarkStandardMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := json.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkStandardUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = json.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}
+
+func BenchmarkJSONIterMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := jsoniter.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkJSONIterUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = jsoniter.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}

--- a/output_tests/maps/builtins/int32/string/types.go
+++ b/output_tests/maps/builtins/int32/string/types.go
@@ -1,0 +1,3 @@
+package test
+
+type T map[int32]string

--- a/output_tests/maps/builtins/int32/string_alias/json_test.go
+++ b/output_tests/maps/builtins/int32/string_alias/json_test.go
@@ -1,0 +1,144 @@
+package test
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/davecgh/go-spew/spew"
+	fuzz "github.com/google/gofuzz"
+	jsoniter "github.com/json-iterator/go"
+)
+
+func Test_Roundtrip(t *testing.T) {
+	fz := fuzz.New().MaxDepth(10).NilChance(0.3)
+	for i := 0; i < 1000; i++ {
+		var before T
+		fz.Fuzz(&before)
+
+		jbStd, err := json.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with stdlib: %v", err)
+		}
+		jbIter, err := jsoniter.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with jsoniter: %v", err)
+		}
+		if string(jbStd) != string(jbIter) {
+			t.Errorf("marshal expected:\n    %s\ngot:\n    %s\nobj:\n    %s",
+				indent(jbStd, "    "), indent(jbIter, "    "), dump(before))
+		}
+
+		var afterStd T
+		err = json.Unmarshal(jbIter, &afterStd)
+		if err != nil {
+			t.Errorf("failed to unmarshal with stdlib: %v", err)
+		}
+		var afterIter T
+		err = jsoniter.Unmarshal(jbIter, &afterIter)
+		if err != nil {
+			t.Errorf("failed to unmarshal with jsoniter: %v", err)
+		}
+		if fingerprint(afterStd) != fingerprint(afterIter) {
+			t.Errorf("unmarshal expected:\n    %s\ngot:\n    %s\nvia:\n    %s",
+				dump(afterStd), dump(afterIter), indent(jbIter, "    "))
+		}
+	}
+}
+
+const indentStr = ">  "
+
+func fingerprint(obj interface{}) string {
+	c := spew.ConfigState{
+		SortKeys: true,
+		SpewKeys: true,
+	}
+	return c.Sprintf("%v", obj)
+}
+
+func dump(obj interface{}) string {
+	cfg := spew.ConfigState{
+		Indent: indentStr,
+	}
+	return cfg.Sdump(obj)
+}
+
+func indent(src []byte, prefix string) string {
+	var buf bytes.Buffer
+	json.Indent(&buf, src, prefix, indentStr)
+	return buf.String()
+}
+
+func BenchmarkStandardMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := json.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkStandardUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = json.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}
+
+func BenchmarkJSONIterMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := jsoniter.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkJSONIterUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = jsoniter.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}

--- a/output_tests/maps/builtins/int32/string_alias/types.go
+++ b/output_tests/maps/builtins/int32/string_alias/types.go
@@ -1,0 +1,5 @@
+package test
+
+type StringAlias string
+
+type T map[int32]StringAlias

--- a/output_tests/maps/builtins/int32/uint8/json_test.go
+++ b/output_tests/maps/builtins/int32/uint8/json_test.go
@@ -1,0 +1,144 @@
+package test
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/davecgh/go-spew/spew"
+	fuzz "github.com/google/gofuzz"
+	jsoniter "github.com/json-iterator/go"
+)
+
+func Test_Roundtrip(t *testing.T) {
+	fz := fuzz.New().MaxDepth(10).NilChance(0.3)
+	for i := 0; i < 1000; i++ {
+		var before T
+		fz.Fuzz(&before)
+
+		jbStd, err := json.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with stdlib: %v", err)
+		}
+		jbIter, err := jsoniter.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with jsoniter: %v", err)
+		}
+		if string(jbStd) != string(jbIter) {
+			t.Errorf("marshal expected:\n    %s\ngot:\n    %s\nobj:\n    %s",
+				indent(jbStd, "    "), indent(jbIter, "    "), dump(before))
+		}
+
+		var afterStd T
+		err = json.Unmarshal(jbIter, &afterStd)
+		if err != nil {
+			t.Errorf("failed to unmarshal with stdlib: %v", err)
+		}
+		var afterIter T
+		err = jsoniter.Unmarshal(jbIter, &afterIter)
+		if err != nil {
+			t.Errorf("failed to unmarshal with jsoniter: %v", err)
+		}
+		if fingerprint(afterStd) != fingerprint(afterIter) {
+			t.Errorf("unmarshal expected:\n    %s\ngot:\n    %s\nvia:\n    %s",
+				dump(afterStd), dump(afterIter), indent(jbIter, "    "))
+		}
+	}
+}
+
+const indentStr = ">  "
+
+func fingerprint(obj interface{}) string {
+	c := spew.ConfigState{
+		SortKeys: true,
+		SpewKeys: true,
+	}
+	return c.Sprintf("%v", obj)
+}
+
+func dump(obj interface{}) string {
+	cfg := spew.ConfigState{
+		Indent: indentStr,
+	}
+	return cfg.Sdump(obj)
+}
+
+func indent(src []byte, prefix string) string {
+	var buf bytes.Buffer
+	json.Indent(&buf, src, prefix, indentStr)
+	return buf.String()
+}
+
+func BenchmarkStandardMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := json.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkStandardUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = json.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}
+
+func BenchmarkJSONIterMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := jsoniter.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkJSONIterUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = jsoniter.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}

--- a/output_tests/maps/builtins/int32/uint8/types.go
+++ b/output_tests/maps/builtins/int32/uint8/types.go
@@ -1,0 +1,3 @@
+package test
+
+type T map[int32]uint8

--- a/output_tests/maps/builtins/string/bool/json_test.go
+++ b/output_tests/maps/builtins/string/bool/json_test.go
@@ -1,0 +1,144 @@
+package test
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/davecgh/go-spew/spew"
+	fuzz "github.com/google/gofuzz"
+	jsoniter "github.com/json-iterator/go"
+)
+
+func Test_Roundtrip(t *testing.T) {
+	fz := fuzz.New().MaxDepth(10).NilChance(0.3)
+	for i := 0; i < 1000; i++ {
+		var before T
+		fz.Fuzz(&before)
+
+		jbStd, err := json.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with stdlib: %v", err)
+		}
+		jbIter, err := jsoniter.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with jsoniter: %v", err)
+		}
+		if string(jbStd) != string(jbIter) {
+			t.Errorf("marshal expected:\n    %s\ngot:\n    %s\nobj:\n    %s",
+				indent(jbStd, "    "), indent(jbIter, "    "), dump(before))
+		}
+
+		var afterStd T
+		err = json.Unmarshal(jbIter, &afterStd)
+		if err != nil {
+			t.Errorf("failed to unmarshal with stdlib: %v", err)
+		}
+		var afterIter T
+		err = jsoniter.Unmarshal(jbIter, &afterIter)
+		if err != nil {
+			t.Errorf("failed to unmarshal with jsoniter: %v", err)
+		}
+		if fingerprint(afterStd) != fingerprint(afterIter) {
+			t.Errorf("unmarshal expected:\n    %s\ngot:\n    %s\nvia:\n    %s",
+				dump(afterStd), dump(afterIter), indent(jbIter, "    "))
+		}
+	}
+}
+
+const indentStr = ">  "
+
+func fingerprint(obj interface{}) string {
+	c := spew.ConfigState{
+		SortKeys: true,
+		SpewKeys: true,
+	}
+	return c.Sprintf("%v", obj)
+}
+
+func dump(obj interface{}) string {
+	cfg := spew.ConfigState{
+		Indent: indentStr,
+	}
+	return cfg.Sdump(obj)
+}
+
+func indent(src []byte, prefix string) string {
+	var buf bytes.Buffer
+	json.Indent(&buf, src, prefix, indentStr)
+	return buf.String()
+}
+
+func BenchmarkStandardMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := json.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkStandardUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = json.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}
+
+func BenchmarkJSONIterMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := jsoniter.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkJSONIterUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = jsoniter.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}

--- a/output_tests/maps/builtins/string/bool/types.go
+++ b/output_tests/maps/builtins/string/bool/types.go
@@ -1,0 +1,3 @@
+package test
+
+type T map[string]bool

--- a/output_tests/maps/builtins/string/byte/json_test.go
+++ b/output_tests/maps/builtins/string/byte/json_test.go
@@ -1,0 +1,144 @@
+package test
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/davecgh/go-spew/spew"
+	fuzz "github.com/google/gofuzz"
+	jsoniter "github.com/json-iterator/go"
+)
+
+func Test_Roundtrip(t *testing.T) {
+	fz := fuzz.New().MaxDepth(10).NilChance(0.3)
+	for i := 0; i < 1000; i++ {
+		var before T
+		fz.Fuzz(&before)
+
+		jbStd, err := json.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with stdlib: %v", err)
+		}
+		jbIter, err := jsoniter.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with jsoniter: %v", err)
+		}
+		if string(jbStd) != string(jbIter) {
+			t.Errorf("marshal expected:\n    %s\ngot:\n    %s\nobj:\n    %s",
+				indent(jbStd, "    "), indent(jbIter, "    "), dump(before))
+		}
+
+		var afterStd T
+		err = json.Unmarshal(jbIter, &afterStd)
+		if err != nil {
+			t.Errorf("failed to unmarshal with stdlib: %v", err)
+		}
+		var afterIter T
+		err = jsoniter.Unmarshal(jbIter, &afterIter)
+		if err != nil {
+			t.Errorf("failed to unmarshal with jsoniter: %v", err)
+		}
+		if fingerprint(afterStd) != fingerprint(afterIter) {
+			t.Errorf("unmarshal expected:\n    %s\ngot:\n    %s\nvia:\n    %s",
+				dump(afterStd), dump(afterIter), indent(jbIter, "    "))
+		}
+	}
+}
+
+const indentStr = ">  "
+
+func fingerprint(obj interface{}) string {
+	c := spew.ConfigState{
+		SortKeys: true,
+		SpewKeys: true,
+	}
+	return c.Sprintf("%v", obj)
+}
+
+func dump(obj interface{}) string {
+	cfg := spew.ConfigState{
+		Indent: indentStr,
+	}
+	return cfg.Sdump(obj)
+}
+
+func indent(src []byte, prefix string) string {
+	var buf bytes.Buffer
+	json.Indent(&buf, src, prefix, indentStr)
+	return buf.String()
+}
+
+func BenchmarkStandardMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := json.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkStandardUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = json.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}
+
+func BenchmarkJSONIterMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := jsoniter.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkJSONIterUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = jsoniter.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}

--- a/output_tests/maps/builtins/string/byte/types.go
+++ b/output_tests/maps/builtins/string/byte/types.go
@@ -1,0 +1,3 @@
+package test
+
+type T map[string]byte

--- a/output_tests/maps/builtins/string/float32/json_test.go
+++ b/output_tests/maps/builtins/string/float32/json_test.go
@@ -1,0 +1,144 @@
+package test
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/davecgh/go-spew/spew"
+	fuzz "github.com/google/gofuzz"
+	jsoniter "github.com/json-iterator/go"
+)
+
+func Test_Roundtrip(t *testing.T) {
+	fz := fuzz.New().MaxDepth(10).NilChance(0.3)
+	for i := 0; i < 1000; i++ {
+		var before T
+		fz.Fuzz(&before)
+
+		jbStd, err := json.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with stdlib: %v", err)
+		}
+		jbIter, err := jsoniter.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with jsoniter: %v", err)
+		}
+		if string(jbStd) != string(jbIter) {
+			t.Errorf("marshal expected:\n    %s\ngot:\n    %s\nobj:\n    %s",
+				indent(jbStd, "    "), indent(jbIter, "    "), dump(before))
+		}
+
+		var afterStd T
+		err = json.Unmarshal(jbIter, &afterStd)
+		if err != nil {
+			t.Errorf("failed to unmarshal with stdlib: %v", err)
+		}
+		var afterIter T
+		err = jsoniter.Unmarshal(jbIter, &afterIter)
+		if err != nil {
+			t.Errorf("failed to unmarshal with jsoniter: %v", err)
+		}
+		if fingerprint(afterStd) != fingerprint(afterIter) {
+			t.Errorf("unmarshal expected:\n    %s\ngot:\n    %s\nvia:\n    %s",
+				dump(afterStd), dump(afterIter), indent(jbIter, "    "))
+		}
+	}
+}
+
+const indentStr = ">  "
+
+func fingerprint(obj interface{}) string {
+	c := spew.ConfigState{
+		SortKeys: true,
+		SpewKeys: true,
+	}
+	return c.Sprintf("%v", obj)
+}
+
+func dump(obj interface{}) string {
+	cfg := spew.ConfigState{
+		Indent: indentStr,
+	}
+	return cfg.Sdump(obj)
+}
+
+func indent(src []byte, prefix string) string {
+	var buf bytes.Buffer
+	json.Indent(&buf, src, prefix, indentStr)
+	return buf.String()
+}
+
+func BenchmarkStandardMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := json.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkStandardUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = json.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}
+
+func BenchmarkJSONIterMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := jsoniter.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkJSONIterUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = jsoniter.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}

--- a/output_tests/maps/builtins/string/float32/types.go
+++ b/output_tests/maps/builtins/string/float32/types.go
@@ -1,0 +1,3 @@
+package test
+
+type T map[string]float32

--- a/output_tests/maps/builtins/string/float64/json_test.go
+++ b/output_tests/maps/builtins/string/float64/json_test.go
@@ -1,0 +1,144 @@
+package test
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/davecgh/go-spew/spew"
+	fuzz "github.com/google/gofuzz"
+	jsoniter "github.com/json-iterator/go"
+)
+
+func Test_Roundtrip(t *testing.T) {
+	fz := fuzz.New().MaxDepth(10).NilChance(0.3)
+	for i := 0; i < 1000; i++ {
+		var before T
+		fz.Fuzz(&before)
+
+		jbStd, err := json.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with stdlib: %v", err)
+		}
+		jbIter, err := jsoniter.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with jsoniter: %v", err)
+		}
+		if string(jbStd) != string(jbIter) {
+			t.Errorf("marshal expected:\n    %s\ngot:\n    %s\nobj:\n    %s",
+				indent(jbStd, "    "), indent(jbIter, "    "), dump(before))
+		}
+
+		var afterStd T
+		err = json.Unmarshal(jbIter, &afterStd)
+		if err != nil {
+			t.Errorf("failed to unmarshal with stdlib: %v", err)
+		}
+		var afterIter T
+		err = jsoniter.Unmarshal(jbIter, &afterIter)
+		if err != nil {
+			t.Errorf("failed to unmarshal with jsoniter: %v", err)
+		}
+		if fingerprint(afterStd) != fingerprint(afterIter) {
+			t.Errorf("unmarshal expected:\n    %s\ngot:\n    %s\nvia:\n    %s",
+				dump(afterStd), dump(afterIter), indent(jbIter, "    "))
+		}
+	}
+}
+
+const indentStr = ">  "
+
+func fingerprint(obj interface{}) string {
+	c := spew.ConfigState{
+		SortKeys: true,
+		SpewKeys: true,
+	}
+	return c.Sprintf("%v", obj)
+}
+
+func dump(obj interface{}) string {
+	cfg := spew.ConfigState{
+		Indent: indentStr,
+	}
+	return cfg.Sdump(obj)
+}
+
+func indent(src []byte, prefix string) string {
+	var buf bytes.Buffer
+	json.Indent(&buf, src, prefix, indentStr)
+	return buf.String()
+}
+
+func BenchmarkStandardMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := json.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkStandardUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = json.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}
+
+func BenchmarkJSONIterMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := jsoniter.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkJSONIterUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = jsoniter.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}

--- a/output_tests/maps/builtins/string/float64/types.go
+++ b/output_tests/maps/builtins/string/float64/types.go
@@ -1,0 +1,3 @@
+package test
+
+type T map[string]float64

--- a/output_tests/maps/builtins/string/int32/json_test.go
+++ b/output_tests/maps/builtins/string/int32/json_test.go
@@ -1,0 +1,144 @@
+package test
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/davecgh/go-spew/spew"
+	fuzz "github.com/google/gofuzz"
+	jsoniter "github.com/json-iterator/go"
+)
+
+func Test_Roundtrip(t *testing.T) {
+	fz := fuzz.New().MaxDepth(10).NilChance(0.3)
+	for i := 0; i < 1000; i++ {
+		var before T
+		fz.Fuzz(&before)
+
+		jbStd, err := json.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with stdlib: %v", err)
+		}
+		jbIter, err := jsoniter.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with jsoniter: %v", err)
+		}
+		if string(jbStd) != string(jbIter) {
+			t.Errorf("marshal expected:\n    %s\ngot:\n    %s\nobj:\n    %s",
+				indent(jbStd, "    "), indent(jbIter, "    "), dump(before))
+		}
+
+		var afterStd T
+		err = json.Unmarshal(jbIter, &afterStd)
+		if err != nil {
+			t.Errorf("failed to unmarshal with stdlib: %v", err)
+		}
+		var afterIter T
+		err = jsoniter.Unmarshal(jbIter, &afterIter)
+		if err != nil {
+			t.Errorf("failed to unmarshal with jsoniter: %v", err)
+		}
+		if fingerprint(afterStd) != fingerprint(afterIter) {
+			t.Errorf("unmarshal expected:\n    %s\ngot:\n    %s\nvia:\n    %s",
+				dump(afterStd), dump(afterIter), indent(jbIter, "    "))
+		}
+	}
+}
+
+const indentStr = ">  "
+
+func fingerprint(obj interface{}) string {
+	c := spew.ConfigState{
+		SortKeys: true,
+		SpewKeys: true,
+	}
+	return c.Sprintf("%v", obj)
+}
+
+func dump(obj interface{}) string {
+	cfg := spew.ConfigState{
+		Indent: indentStr,
+	}
+	return cfg.Sdump(obj)
+}
+
+func indent(src []byte, prefix string) string {
+	var buf bytes.Buffer
+	json.Indent(&buf, src, prefix, indentStr)
+	return buf.String()
+}
+
+func BenchmarkStandardMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := json.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkStandardUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = json.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}
+
+func BenchmarkJSONIterMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := jsoniter.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkJSONIterUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = jsoniter.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}

--- a/output_tests/maps/builtins/string/int32/types.go
+++ b/output_tests/maps/builtins/string/int32/types.go
@@ -1,0 +1,3 @@
+package test
+
+type T map[string]int32

--- a/output_tests/maps/builtins/string/int8/json_test.go
+++ b/output_tests/maps/builtins/string/int8/json_test.go
@@ -1,0 +1,144 @@
+package test
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/davecgh/go-spew/spew"
+	fuzz "github.com/google/gofuzz"
+	jsoniter "github.com/json-iterator/go"
+)
+
+func Test_Roundtrip(t *testing.T) {
+	fz := fuzz.New().MaxDepth(10).NilChance(0.3)
+	for i := 0; i < 1000; i++ {
+		var before T
+		fz.Fuzz(&before)
+
+		jbStd, err := json.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with stdlib: %v", err)
+		}
+		jbIter, err := jsoniter.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with jsoniter: %v", err)
+		}
+		if string(jbStd) != string(jbIter) {
+			t.Errorf("marshal expected:\n    %s\ngot:\n    %s\nobj:\n    %s",
+				indent(jbStd, "    "), indent(jbIter, "    "), dump(before))
+		}
+
+		var afterStd T
+		err = json.Unmarshal(jbIter, &afterStd)
+		if err != nil {
+			t.Errorf("failed to unmarshal with stdlib: %v", err)
+		}
+		var afterIter T
+		err = jsoniter.Unmarshal(jbIter, &afterIter)
+		if err != nil {
+			t.Errorf("failed to unmarshal with jsoniter: %v", err)
+		}
+		if fingerprint(afterStd) != fingerprint(afterIter) {
+			t.Errorf("unmarshal expected:\n    %s\ngot:\n    %s\nvia:\n    %s",
+				dump(afterStd), dump(afterIter), indent(jbIter, "    "))
+		}
+	}
+}
+
+const indentStr = ">  "
+
+func fingerprint(obj interface{}) string {
+	c := spew.ConfigState{
+		SortKeys: true,
+		SpewKeys: true,
+	}
+	return c.Sprintf("%v", obj)
+}
+
+func dump(obj interface{}) string {
+	cfg := spew.ConfigState{
+		Indent: indentStr,
+	}
+	return cfg.Sdump(obj)
+}
+
+func indent(src []byte, prefix string) string {
+	var buf bytes.Buffer
+	json.Indent(&buf, src, prefix, indentStr)
+	return buf.String()
+}
+
+func BenchmarkStandardMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := json.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkStandardUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = json.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}
+
+func BenchmarkJSONIterMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := jsoniter.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkJSONIterUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = jsoniter.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}

--- a/output_tests/maps/builtins/string/int8/types.go
+++ b/output_tests/maps/builtins/string/int8/types.go
@@ -1,0 +1,3 @@
+package test
+
+type T map[string]int8

--- a/output_tests/maps/builtins/string/string/json_test.go
+++ b/output_tests/maps/builtins/string/string/json_test.go
@@ -1,0 +1,144 @@
+package test
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/davecgh/go-spew/spew"
+	fuzz "github.com/google/gofuzz"
+	jsoniter "github.com/json-iterator/go"
+)
+
+func Test_Roundtrip(t *testing.T) {
+	fz := fuzz.New().MaxDepth(10).NilChance(0.3)
+	for i := 0; i < 1000; i++ {
+		var before T
+		fz.Fuzz(&before)
+
+		jbStd, err := json.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with stdlib: %v", err)
+		}
+		jbIter, err := jsoniter.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with jsoniter: %v", err)
+		}
+		if string(jbStd) != string(jbIter) {
+			t.Errorf("marshal expected:\n    %s\ngot:\n    %s\nobj:\n    %s",
+				indent(jbStd, "    "), indent(jbIter, "    "), dump(before))
+		}
+
+		var afterStd T
+		err = json.Unmarshal(jbIter, &afterStd)
+		if err != nil {
+			t.Errorf("failed to unmarshal with stdlib: %v", err)
+		}
+		var afterIter T
+		err = jsoniter.Unmarshal(jbIter, &afterIter)
+		if err != nil {
+			t.Errorf("failed to unmarshal with jsoniter: %v", err)
+		}
+		if fingerprint(afterStd) != fingerprint(afterIter) {
+			t.Errorf("unmarshal expected:\n    %s\ngot:\n    %s\nvia:\n    %s",
+				dump(afterStd), dump(afterIter), indent(jbIter, "    "))
+		}
+	}
+}
+
+const indentStr = ">  "
+
+func fingerprint(obj interface{}) string {
+	c := spew.ConfigState{
+		SortKeys: true,
+		SpewKeys: true,
+	}
+	return c.Sprintf("%v", obj)
+}
+
+func dump(obj interface{}) string {
+	cfg := spew.ConfigState{
+		Indent: indentStr,
+	}
+	return cfg.Sdump(obj)
+}
+
+func indent(src []byte, prefix string) string {
+	var buf bytes.Buffer
+	json.Indent(&buf, src, prefix, indentStr)
+	return buf.String()
+}
+
+func BenchmarkStandardMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := json.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkStandardUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = json.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}
+
+func BenchmarkJSONIterMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := jsoniter.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkJSONIterUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = jsoniter.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}

--- a/output_tests/maps/builtins/string/string/types.go
+++ b/output_tests/maps/builtins/string/string/types.go
@@ -1,0 +1,3 @@
+package test
+
+type T map[string]string

--- a/output_tests/maps/builtins/string/string_alias/json_test.go
+++ b/output_tests/maps/builtins/string/string_alias/json_test.go
@@ -1,0 +1,144 @@
+package test
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/davecgh/go-spew/spew"
+	fuzz "github.com/google/gofuzz"
+	jsoniter "github.com/json-iterator/go"
+)
+
+func Test_Roundtrip(t *testing.T) {
+	fz := fuzz.New().MaxDepth(10).NilChance(0.3)
+	for i := 0; i < 1000; i++ {
+		var before T
+		fz.Fuzz(&before)
+
+		jbStd, err := json.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with stdlib: %v", err)
+		}
+		jbIter, err := jsoniter.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with jsoniter: %v", err)
+		}
+		if string(jbStd) != string(jbIter) {
+			t.Errorf("marshal expected:\n    %s\ngot:\n    %s\nobj:\n    %s",
+				indent(jbStd, "    "), indent(jbIter, "    "), dump(before))
+		}
+
+		var afterStd T
+		err = json.Unmarshal(jbIter, &afterStd)
+		if err != nil {
+			t.Errorf("failed to unmarshal with stdlib: %v", err)
+		}
+		var afterIter T
+		err = jsoniter.Unmarshal(jbIter, &afterIter)
+		if err != nil {
+			t.Errorf("failed to unmarshal with jsoniter: %v", err)
+		}
+		if fingerprint(afterStd) != fingerprint(afterIter) {
+			t.Errorf("unmarshal expected:\n    %s\ngot:\n    %s\nvia:\n    %s",
+				dump(afterStd), dump(afterIter), indent(jbIter, "    "))
+		}
+	}
+}
+
+const indentStr = ">  "
+
+func fingerprint(obj interface{}) string {
+	c := spew.ConfigState{
+		SortKeys: true,
+		SpewKeys: true,
+	}
+	return c.Sprintf("%v", obj)
+}
+
+func dump(obj interface{}) string {
+	cfg := spew.ConfigState{
+		Indent: indentStr,
+	}
+	return cfg.Sdump(obj)
+}
+
+func indent(src []byte, prefix string) string {
+	var buf bytes.Buffer
+	json.Indent(&buf, src, prefix, indentStr)
+	return buf.String()
+}
+
+func BenchmarkStandardMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := json.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkStandardUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = json.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}
+
+func BenchmarkJSONIterMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := jsoniter.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkJSONIterUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = jsoniter.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}

--- a/output_tests/maps/builtins/string/string_alias/types.go
+++ b/output_tests/maps/builtins/string/string_alias/types.go
@@ -1,0 +1,5 @@
+package test
+
+type StringAlias string
+
+type T map[string]StringAlias

--- a/output_tests/maps/builtins/string/uint8/json_test.go
+++ b/output_tests/maps/builtins/string/uint8/json_test.go
@@ -1,0 +1,144 @@
+package test
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/davecgh/go-spew/spew"
+	fuzz "github.com/google/gofuzz"
+	jsoniter "github.com/json-iterator/go"
+)
+
+func Test_Roundtrip(t *testing.T) {
+	fz := fuzz.New().MaxDepth(10).NilChance(0.3)
+	for i := 0; i < 1000; i++ {
+		var before T
+		fz.Fuzz(&before)
+
+		jbStd, err := json.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with stdlib: %v", err)
+		}
+		jbIter, err := jsoniter.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with jsoniter: %v", err)
+		}
+		if string(jbStd) != string(jbIter) {
+			t.Errorf("marshal expected:\n    %s\ngot:\n    %s\nobj:\n    %s",
+				indent(jbStd, "    "), indent(jbIter, "    "), dump(before))
+		}
+
+		var afterStd T
+		err = json.Unmarshal(jbIter, &afterStd)
+		if err != nil {
+			t.Errorf("failed to unmarshal with stdlib: %v", err)
+		}
+		var afterIter T
+		err = jsoniter.Unmarshal(jbIter, &afterIter)
+		if err != nil {
+			t.Errorf("failed to unmarshal with jsoniter: %v", err)
+		}
+		if fingerprint(afterStd) != fingerprint(afterIter) {
+			t.Errorf("unmarshal expected:\n    %s\ngot:\n    %s\nvia:\n    %s",
+				dump(afterStd), dump(afterIter), indent(jbIter, "    "))
+		}
+	}
+}
+
+const indentStr = ">  "
+
+func fingerprint(obj interface{}) string {
+	c := spew.ConfigState{
+		SortKeys: true,
+		SpewKeys: true,
+	}
+	return c.Sprintf("%v", obj)
+}
+
+func dump(obj interface{}) string {
+	cfg := spew.ConfigState{
+		Indent: indentStr,
+	}
+	return cfg.Sdump(obj)
+}
+
+func indent(src []byte, prefix string) string {
+	var buf bytes.Buffer
+	json.Indent(&buf, src, prefix, indentStr)
+	return buf.String()
+}
+
+func BenchmarkStandardMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := json.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkStandardUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = json.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}
+
+func BenchmarkJSONIterMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := jsoniter.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkJSONIterUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = jsoniter.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}

--- a/output_tests/maps/builtins/string/uint8/types.go
+++ b/output_tests/maps/builtins/string/uint8/types.go
@@ -1,0 +1,3 @@
+package test
+
+type T map[string]uint8

--- a/output_tests/maps/builtins/string_alias/bool/json_test.go
+++ b/output_tests/maps/builtins/string_alias/bool/json_test.go
@@ -1,0 +1,144 @@
+package test
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/davecgh/go-spew/spew"
+	fuzz "github.com/google/gofuzz"
+	jsoniter "github.com/json-iterator/go"
+)
+
+func Test_Roundtrip(t *testing.T) {
+	fz := fuzz.New().MaxDepth(10).NilChance(0.3)
+	for i := 0; i < 1000; i++ {
+		var before T
+		fz.Fuzz(&before)
+
+		jbStd, err := json.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with stdlib: %v", err)
+		}
+		jbIter, err := jsoniter.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with jsoniter: %v", err)
+		}
+		if string(jbStd) != string(jbIter) {
+			t.Errorf("marshal expected:\n    %s\ngot:\n    %s\nobj:\n    %s",
+				indent(jbStd, "    "), indent(jbIter, "    "), dump(before))
+		}
+
+		var afterStd T
+		err = json.Unmarshal(jbIter, &afterStd)
+		if err != nil {
+			t.Errorf("failed to unmarshal with stdlib: %v", err)
+		}
+		var afterIter T
+		err = jsoniter.Unmarshal(jbIter, &afterIter)
+		if err != nil {
+			t.Errorf("failed to unmarshal with jsoniter: %v", err)
+		}
+		if fingerprint(afterStd) != fingerprint(afterIter) {
+			t.Errorf("unmarshal expected:\n    %s\ngot:\n    %s\nvia:\n    %s",
+				dump(afterStd), dump(afterIter), indent(jbIter, "    "))
+		}
+	}
+}
+
+const indentStr = ">  "
+
+func fingerprint(obj interface{}) string {
+	c := spew.ConfigState{
+		SortKeys: true,
+		SpewKeys: true,
+	}
+	return c.Sprintf("%v", obj)
+}
+
+func dump(obj interface{}) string {
+	cfg := spew.ConfigState{
+		Indent: indentStr,
+	}
+	return cfg.Sdump(obj)
+}
+
+func indent(src []byte, prefix string) string {
+	var buf bytes.Buffer
+	json.Indent(&buf, src, prefix, indentStr)
+	return buf.String()
+}
+
+func BenchmarkStandardMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := json.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkStandardUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = json.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}
+
+func BenchmarkJSONIterMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := jsoniter.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkJSONIterUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = jsoniter.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}

--- a/output_tests/maps/builtins/string_alias/bool/types.go
+++ b/output_tests/maps/builtins/string_alias/bool/types.go
@@ -1,0 +1,5 @@
+package test
+
+type StringAlias string
+
+type T map[StringAlias]bool

--- a/output_tests/maps/builtins/string_alias/byte/json_test.go
+++ b/output_tests/maps/builtins/string_alias/byte/json_test.go
@@ -1,0 +1,144 @@
+package test
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/davecgh/go-spew/spew"
+	fuzz "github.com/google/gofuzz"
+	jsoniter "github.com/json-iterator/go"
+)
+
+func Test_Roundtrip(t *testing.T) {
+	fz := fuzz.New().MaxDepth(10).NilChance(0.3)
+	for i := 0; i < 1000; i++ {
+		var before T
+		fz.Fuzz(&before)
+
+		jbStd, err := json.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with stdlib: %v", err)
+		}
+		jbIter, err := jsoniter.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with jsoniter: %v", err)
+		}
+		if string(jbStd) != string(jbIter) {
+			t.Errorf("marshal expected:\n    %s\ngot:\n    %s\nobj:\n    %s",
+				indent(jbStd, "    "), indent(jbIter, "    "), dump(before))
+		}
+
+		var afterStd T
+		err = json.Unmarshal(jbIter, &afterStd)
+		if err != nil {
+			t.Errorf("failed to unmarshal with stdlib: %v", err)
+		}
+		var afterIter T
+		err = jsoniter.Unmarshal(jbIter, &afterIter)
+		if err != nil {
+			t.Errorf("failed to unmarshal with jsoniter: %v", err)
+		}
+		if fingerprint(afterStd) != fingerprint(afterIter) {
+			t.Errorf("unmarshal expected:\n    %s\ngot:\n    %s\nvia:\n    %s",
+				dump(afterStd), dump(afterIter), indent(jbIter, "    "))
+		}
+	}
+}
+
+const indentStr = ">  "
+
+func fingerprint(obj interface{}) string {
+	c := spew.ConfigState{
+		SortKeys: true,
+		SpewKeys: true,
+	}
+	return c.Sprintf("%v", obj)
+}
+
+func dump(obj interface{}) string {
+	cfg := spew.ConfigState{
+		Indent: indentStr,
+	}
+	return cfg.Sdump(obj)
+}
+
+func indent(src []byte, prefix string) string {
+	var buf bytes.Buffer
+	json.Indent(&buf, src, prefix, indentStr)
+	return buf.String()
+}
+
+func BenchmarkStandardMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := json.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkStandardUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = json.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}
+
+func BenchmarkJSONIterMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := jsoniter.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkJSONIterUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = jsoniter.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}

--- a/output_tests/maps/builtins/string_alias/byte/types.go
+++ b/output_tests/maps/builtins/string_alias/byte/types.go
@@ -1,0 +1,5 @@
+package test
+
+type StringAlias string
+
+type T map[StringAlias]byte

--- a/output_tests/maps/builtins/string_alias/float32/json_test.go
+++ b/output_tests/maps/builtins/string_alias/float32/json_test.go
@@ -1,0 +1,144 @@
+package test
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/davecgh/go-spew/spew"
+	fuzz "github.com/google/gofuzz"
+	jsoniter "github.com/json-iterator/go"
+)
+
+func Test_Roundtrip(t *testing.T) {
+	fz := fuzz.New().MaxDepth(10).NilChance(0.3)
+	for i := 0; i < 1000; i++ {
+		var before T
+		fz.Fuzz(&before)
+
+		jbStd, err := json.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with stdlib: %v", err)
+		}
+		jbIter, err := jsoniter.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with jsoniter: %v", err)
+		}
+		if string(jbStd) != string(jbIter) {
+			t.Errorf("marshal expected:\n    %s\ngot:\n    %s\nobj:\n    %s",
+				indent(jbStd, "    "), indent(jbIter, "    "), dump(before))
+		}
+
+		var afterStd T
+		err = json.Unmarshal(jbIter, &afterStd)
+		if err != nil {
+			t.Errorf("failed to unmarshal with stdlib: %v", err)
+		}
+		var afterIter T
+		err = jsoniter.Unmarshal(jbIter, &afterIter)
+		if err != nil {
+			t.Errorf("failed to unmarshal with jsoniter: %v", err)
+		}
+		if fingerprint(afterStd) != fingerprint(afterIter) {
+			t.Errorf("unmarshal expected:\n    %s\ngot:\n    %s\nvia:\n    %s",
+				dump(afterStd), dump(afterIter), indent(jbIter, "    "))
+		}
+	}
+}
+
+const indentStr = ">  "
+
+func fingerprint(obj interface{}) string {
+	c := spew.ConfigState{
+		SortKeys: true,
+		SpewKeys: true,
+	}
+	return c.Sprintf("%v", obj)
+}
+
+func dump(obj interface{}) string {
+	cfg := spew.ConfigState{
+		Indent: indentStr,
+	}
+	return cfg.Sdump(obj)
+}
+
+func indent(src []byte, prefix string) string {
+	var buf bytes.Buffer
+	json.Indent(&buf, src, prefix, indentStr)
+	return buf.String()
+}
+
+func BenchmarkStandardMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := json.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkStandardUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = json.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}
+
+func BenchmarkJSONIterMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := jsoniter.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkJSONIterUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = jsoniter.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}

--- a/output_tests/maps/builtins/string_alias/float32/types.go
+++ b/output_tests/maps/builtins/string_alias/float32/types.go
@@ -1,0 +1,5 @@
+package test
+
+type StringAlias string
+
+type T map[StringAlias]float32

--- a/output_tests/maps/builtins/string_alias/float64/json_test.go
+++ b/output_tests/maps/builtins/string_alias/float64/json_test.go
@@ -1,0 +1,144 @@
+package test
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/davecgh/go-spew/spew"
+	fuzz "github.com/google/gofuzz"
+	jsoniter "github.com/json-iterator/go"
+)
+
+func Test_Roundtrip(t *testing.T) {
+	fz := fuzz.New().MaxDepth(10).NilChance(0.3)
+	for i := 0; i < 1000; i++ {
+		var before T
+		fz.Fuzz(&before)
+
+		jbStd, err := json.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with stdlib: %v", err)
+		}
+		jbIter, err := jsoniter.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with jsoniter: %v", err)
+		}
+		if string(jbStd) != string(jbIter) {
+			t.Errorf("marshal expected:\n    %s\ngot:\n    %s\nobj:\n    %s",
+				indent(jbStd, "    "), indent(jbIter, "    "), dump(before))
+		}
+
+		var afterStd T
+		err = json.Unmarshal(jbIter, &afterStd)
+		if err != nil {
+			t.Errorf("failed to unmarshal with stdlib: %v", err)
+		}
+		var afterIter T
+		err = jsoniter.Unmarshal(jbIter, &afterIter)
+		if err != nil {
+			t.Errorf("failed to unmarshal with jsoniter: %v", err)
+		}
+		if fingerprint(afterStd) != fingerprint(afterIter) {
+			t.Errorf("unmarshal expected:\n    %s\ngot:\n    %s\nvia:\n    %s",
+				dump(afterStd), dump(afterIter), indent(jbIter, "    "))
+		}
+	}
+}
+
+const indentStr = ">  "
+
+func fingerprint(obj interface{}) string {
+	c := spew.ConfigState{
+		SortKeys: true,
+		SpewKeys: true,
+	}
+	return c.Sprintf("%v", obj)
+}
+
+func dump(obj interface{}) string {
+	cfg := spew.ConfigState{
+		Indent: indentStr,
+	}
+	return cfg.Sdump(obj)
+}
+
+func indent(src []byte, prefix string) string {
+	var buf bytes.Buffer
+	json.Indent(&buf, src, prefix, indentStr)
+	return buf.String()
+}
+
+func BenchmarkStandardMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := json.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkStandardUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = json.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}
+
+func BenchmarkJSONIterMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := jsoniter.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkJSONIterUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = jsoniter.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}

--- a/output_tests/maps/builtins/string_alias/float64/types.go
+++ b/output_tests/maps/builtins/string_alias/float64/types.go
@@ -1,0 +1,5 @@
+package test
+
+type StringAlias string
+
+type T map[StringAlias]float64

--- a/output_tests/maps/builtins/string_alias/int32/json_test.go
+++ b/output_tests/maps/builtins/string_alias/int32/json_test.go
@@ -1,0 +1,144 @@
+package test
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/davecgh/go-spew/spew"
+	fuzz "github.com/google/gofuzz"
+	jsoniter "github.com/json-iterator/go"
+)
+
+func Test_Roundtrip(t *testing.T) {
+	fz := fuzz.New().MaxDepth(10).NilChance(0.3)
+	for i := 0; i < 1000; i++ {
+		var before T
+		fz.Fuzz(&before)
+
+		jbStd, err := json.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with stdlib: %v", err)
+		}
+		jbIter, err := jsoniter.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with jsoniter: %v", err)
+		}
+		if string(jbStd) != string(jbIter) {
+			t.Errorf("marshal expected:\n    %s\ngot:\n    %s\nobj:\n    %s",
+				indent(jbStd, "    "), indent(jbIter, "    "), dump(before))
+		}
+
+		var afterStd T
+		err = json.Unmarshal(jbIter, &afterStd)
+		if err != nil {
+			t.Errorf("failed to unmarshal with stdlib: %v", err)
+		}
+		var afterIter T
+		err = jsoniter.Unmarshal(jbIter, &afterIter)
+		if err != nil {
+			t.Errorf("failed to unmarshal with jsoniter: %v", err)
+		}
+		if fingerprint(afterStd) != fingerprint(afterIter) {
+			t.Errorf("unmarshal expected:\n    %s\ngot:\n    %s\nvia:\n    %s",
+				dump(afterStd), dump(afterIter), indent(jbIter, "    "))
+		}
+	}
+}
+
+const indentStr = ">  "
+
+func fingerprint(obj interface{}) string {
+	c := spew.ConfigState{
+		SortKeys: true,
+		SpewKeys: true,
+	}
+	return c.Sprintf("%v", obj)
+}
+
+func dump(obj interface{}) string {
+	cfg := spew.ConfigState{
+		Indent: indentStr,
+	}
+	return cfg.Sdump(obj)
+}
+
+func indent(src []byte, prefix string) string {
+	var buf bytes.Buffer
+	json.Indent(&buf, src, prefix, indentStr)
+	return buf.String()
+}
+
+func BenchmarkStandardMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := json.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkStandardUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = json.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}
+
+func BenchmarkJSONIterMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := jsoniter.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkJSONIterUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = jsoniter.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}

--- a/output_tests/maps/builtins/string_alias/int32/types.go
+++ b/output_tests/maps/builtins/string_alias/int32/types.go
@@ -1,0 +1,5 @@
+package test
+
+type StringAlias string
+
+type T map[StringAlias]int32

--- a/output_tests/maps/builtins/string_alias/int8/json_test.go
+++ b/output_tests/maps/builtins/string_alias/int8/json_test.go
@@ -1,0 +1,144 @@
+package test
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/davecgh/go-spew/spew"
+	fuzz "github.com/google/gofuzz"
+	jsoniter "github.com/json-iterator/go"
+)
+
+func Test_Roundtrip(t *testing.T) {
+	fz := fuzz.New().MaxDepth(10).NilChance(0.3)
+	for i := 0; i < 1000; i++ {
+		var before T
+		fz.Fuzz(&before)
+
+		jbStd, err := json.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with stdlib: %v", err)
+		}
+		jbIter, err := jsoniter.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with jsoniter: %v", err)
+		}
+		if string(jbStd) != string(jbIter) {
+			t.Errorf("marshal expected:\n    %s\ngot:\n    %s\nobj:\n    %s",
+				indent(jbStd, "    "), indent(jbIter, "    "), dump(before))
+		}
+
+		var afterStd T
+		err = json.Unmarshal(jbIter, &afterStd)
+		if err != nil {
+			t.Errorf("failed to unmarshal with stdlib: %v", err)
+		}
+		var afterIter T
+		err = jsoniter.Unmarshal(jbIter, &afterIter)
+		if err != nil {
+			t.Errorf("failed to unmarshal with jsoniter: %v", err)
+		}
+		if fingerprint(afterStd) != fingerprint(afterIter) {
+			t.Errorf("unmarshal expected:\n    %s\ngot:\n    %s\nvia:\n    %s",
+				dump(afterStd), dump(afterIter), indent(jbIter, "    "))
+		}
+	}
+}
+
+const indentStr = ">  "
+
+func fingerprint(obj interface{}) string {
+	c := spew.ConfigState{
+		SortKeys: true,
+		SpewKeys: true,
+	}
+	return c.Sprintf("%v", obj)
+}
+
+func dump(obj interface{}) string {
+	cfg := spew.ConfigState{
+		Indent: indentStr,
+	}
+	return cfg.Sdump(obj)
+}
+
+func indent(src []byte, prefix string) string {
+	var buf bytes.Buffer
+	json.Indent(&buf, src, prefix, indentStr)
+	return buf.String()
+}
+
+func BenchmarkStandardMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := json.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkStandardUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = json.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}
+
+func BenchmarkJSONIterMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := jsoniter.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkJSONIterUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = jsoniter.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}

--- a/output_tests/maps/builtins/string_alias/int8/types.go
+++ b/output_tests/maps/builtins/string_alias/int8/types.go
@@ -1,0 +1,5 @@
+package test
+
+type StringAlias string
+
+type T map[StringAlias]int8

--- a/output_tests/maps/builtins/string_alias/string/json_test.go
+++ b/output_tests/maps/builtins/string_alias/string/json_test.go
@@ -1,0 +1,144 @@
+package test
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/davecgh/go-spew/spew"
+	fuzz "github.com/google/gofuzz"
+	jsoniter "github.com/json-iterator/go"
+)
+
+func Test_Roundtrip(t *testing.T) {
+	fz := fuzz.New().MaxDepth(10).NilChance(0.3)
+	for i := 0; i < 1000; i++ {
+		var before T
+		fz.Fuzz(&before)
+
+		jbStd, err := json.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with stdlib: %v", err)
+		}
+		jbIter, err := jsoniter.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with jsoniter: %v", err)
+		}
+		if string(jbStd) != string(jbIter) {
+			t.Errorf("marshal expected:\n    %s\ngot:\n    %s\nobj:\n    %s",
+				indent(jbStd, "    "), indent(jbIter, "    "), dump(before))
+		}
+
+		var afterStd T
+		err = json.Unmarshal(jbIter, &afterStd)
+		if err != nil {
+			t.Errorf("failed to unmarshal with stdlib: %v", err)
+		}
+		var afterIter T
+		err = jsoniter.Unmarshal(jbIter, &afterIter)
+		if err != nil {
+			t.Errorf("failed to unmarshal with jsoniter: %v", err)
+		}
+		if fingerprint(afterStd) != fingerprint(afterIter) {
+			t.Errorf("unmarshal expected:\n    %s\ngot:\n    %s\nvia:\n    %s",
+				dump(afterStd), dump(afterIter), indent(jbIter, "    "))
+		}
+	}
+}
+
+const indentStr = ">  "
+
+func fingerprint(obj interface{}) string {
+	c := spew.ConfigState{
+		SortKeys: true,
+		SpewKeys: true,
+	}
+	return c.Sprintf("%v", obj)
+}
+
+func dump(obj interface{}) string {
+	cfg := spew.ConfigState{
+		Indent: indentStr,
+	}
+	return cfg.Sdump(obj)
+}
+
+func indent(src []byte, prefix string) string {
+	var buf bytes.Buffer
+	json.Indent(&buf, src, prefix, indentStr)
+	return buf.String()
+}
+
+func BenchmarkStandardMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := json.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkStandardUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = json.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}
+
+func BenchmarkJSONIterMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := jsoniter.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkJSONIterUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = jsoniter.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}

--- a/output_tests/maps/builtins/string_alias/string/types.go
+++ b/output_tests/maps/builtins/string_alias/string/types.go
@@ -1,0 +1,5 @@
+package test
+
+type StringAlias string
+
+type T map[StringAlias]string

--- a/output_tests/maps/builtins/string_alias/string_alias/json_test.go
+++ b/output_tests/maps/builtins/string_alias/string_alias/json_test.go
@@ -1,0 +1,144 @@
+package test
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/davecgh/go-spew/spew"
+	fuzz "github.com/google/gofuzz"
+	jsoniter "github.com/json-iterator/go"
+)
+
+func Test_Roundtrip(t *testing.T) {
+	fz := fuzz.New().MaxDepth(10).NilChance(0.3)
+	for i := 0; i < 1000; i++ {
+		var before T
+		fz.Fuzz(&before)
+
+		jbStd, err := json.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with stdlib: %v", err)
+		}
+		jbIter, err := jsoniter.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with jsoniter: %v", err)
+		}
+		if string(jbStd) != string(jbIter) {
+			t.Errorf("marshal expected:\n    %s\ngot:\n    %s\nobj:\n    %s",
+				indent(jbStd, "    "), indent(jbIter, "    "), dump(before))
+		}
+
+		var afterStd T
+		err = json.Unmarshal(jbIter, &afterStd)
+		if err != nil {
+			t.Errorf("failed to unmarshal with stdlib: %v", err)
+		}
+		var afterIter T
+		err = jsoniter.Unmarshal(jbIter, &afterIter)
+		if err != nil {
+			t.Errorf("failed to unmarshal with jsoniter: %v", err)
+		}
+		if fingerprint(afterStd) != fingerprint(afterIter) {
+			t.Errorf("unmarshal expected:\n    %s\ngot:\n    %s\nvia:\n    %s",
+				dump(afterStd), dump(afterIter), indent(jbIter, "    "))
+		}
+	}
+}
+
+const indentStr = ">  "
+
+func fingerprint(obj interface{}) string {
+	c := spew.ConfigState{
+		SortKeys: true,
+		SpewKeys: true,
+	}
+	return c.Sprintf("%v", obj)
+}
+
+func dump(obj interface{}) string {
+	cfg := spew.ConfigState{
+		Indent: indentStr,
+	}
+	return cfg.Sdump(obj)
+}
+
+func indent(src []byte, prefix string) string {
+	var buf bytes.Buffer
+	json.Indent(&buf, src, prefix, indentStr)
+	return buf.String()
+}
+
+func BenchmarkStandardMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := json.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkStandardUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = json.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}
+
+func BenchmarkJSONIterMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := jsoniter.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkJSONIterUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = jsoniter.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}

--- a/output_tests/maps/builtins/string_alias/string_alias/types.go
+++ b/output_tests/maps/builtins/string_alias/string_alias/types.go
@@ -1,0 +1,5 @@
+package test
+
+type StringAlias string
+
+type T map[StringAlias]StringAlias

--- a/output_tests/maps/builtins/string_alias/uint8/json_test.go
+++ b/output_tests/maps/builtins/string_alias/uint8/json_test.go
@@ -1,0 +1,144 @@
+package test
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/davecgh/go-spew/spew"
+	fuzz "github.com/google/gofuzz"
+	jsoniter "github.com/json-iterator/go"
+)
+
+func Test_Roundtrip(t *testing.T) {
+	fz := fuzz.New().MaxDepth(10).NilChance(0.3)
+	for i := 0; i < 1000; i++ {
+		var before T
+		fz.Fuzz(&before)
+
+		jbStd, err := json.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with stdlib: %v", err)
+		}
+		jbIter, err := jsoniter.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with jsoniter: %v", err)
+		}
+		if string(jbStd) != string(jbIter) {
+			t.Errorf("marshal expected:\n    %s\ngot:\n    %s\nobj:\n    %s",
+				indent(jbStd, "    "), indent(jbIter, "    "), dump(before))
+		}
+
+		var afterStd T
+		err = json.Unmarshal(jbIter, &afterStd)
+		if err != nil {
+			t.Errorf("failed to unmarshal with stdlib: %v", err)
+		}
+		var afterIter T
+		err = jsoniter.Unmarshal(jbIter, &afterIter)
+		if err != nil {
+			t.Errorf("failed to unmarshal with jsoniter: %v", err)
+		}
+		if fingerprint(afterStd) != fingerprint(afterIter) {
+			t.Errorf("unmarshal expected:\n    %s\ngot:\n    %s\nvia:\n    %s",
+				dump(afterStd), dump(afterIter), indent(jbIter, "    "))
+		}
+	}
+}
+
+const indentStr = ">  "
+
+func fingerprint(obj interface{}) string {
+	c := spew.ConfigState{
+		SortKeys: true,
+		SpewKeys: true,
+	}
+	return c.Sprintf("%v", obj)
+}
+
+func dump(obj interface{}) string {
+	cfg := spew.ConfigState{
+		Indent: indentStr,
+	}
+	return cfg.Sdump(obj)
+}
+
+func indent(src []byte, prefix string) string {
+	var buf bytes.Buffer
+	json.Indent(&buf, src, prefix, indentStr)
+	return buf.String()
+}
+
+func BenchmarkStandardMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := json.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkStandardUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = json.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}
+
+func BenchmarkJSONIterMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := jsoniter.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkJSONIterUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = jsoniter.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}

--- a/output_tests/maps/builtins/string_alias/uint8/types.go
+++ b/output_tests/maps/builtins/string_alias/uint8/types.go
@@ -1,0 +1,5 @@
+package test
+
+type StringAlias string
+
+type T map[StringAlias]uint8

--- a/output_tests/maps/builtins/uint8/bool/json_test.go
+++ b/output_tests/maps/builtins/uint8/bool/json_test.go
@@ -1,0 +1,144 @@
+package test
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/davecgh/go-spew/spew"
+	fuzz "github.com/google/gofuzz"
+	jsoniter "github.com/json-iterator/go"
+)
+
+func Test_Roundtrip(t *testing.T) {
+	fz := fuzz.New().MaxDepth(10).NilChance(0.3)
+	for i := 0; i < 1000; i++ {
+		var before T
+		fz.Fuzz(&before)
+
+		jbStd, err := json.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with stdlib: %v", err)
+		}
+		jbIter, err := jsoniter.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with jsoniter: %v", err)
+		}
+		if string(jbStd) != string(jbIter) {
+			t.Errorf("marshal expected:\n    %s\ngot:\n    %s\nobj:\n    %s",
+				indent(jbStd, "    "), indent(jbIter, "    "), dump(before))
+		}
+
+		var afterStd T
+		err = json.Unmarshal(jbIter, &afterStd)
+		if err != nil {
+			t.Errorf("failed to unmarshal with stdlib: %v", err)
+		}
+		var afterIter T
+		err = jsoniter.Unmarshal(jbIter, &afterIter)
+		if err != nil {
+			t.Errorf("failed to unmarshal with jsoniter: %v", err)
+		}
+		if fingerprint(afterStd) != fingerprint(afterIter) {
+			t.Errorf("unmarshal expected:\n    %s\ngot:\n    %s\nvia:\n    %s",
+				dump(afterStd), dump(afterIter), indent(jbIter, "    "))
+		}
+	}
+}
+
+const indentStr = ">  "
+
+func fingerprint(obj interface{}) string {
+	c := spew.ConfigState{
+		SortKeys: true,
+		SpewKeys: true,
+	}
+	return c.Sprintf("%v", obj)
+}
+
+func dump(obj interface{}) string {
+	cfg := spew.ConfigState{
+		Indent: indentStr,
+	}
+	return cfg.Sdump(obj)
+}
+
+func indent(src []byte, prefix string) string {
+	var buf bytes.Buffer
+	json.Indent(&buf, src, prefix, indentStr)
+	return buf.String()
+}
+
+func BenchmarkStandardMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := json.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkStandardUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = json.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}
+
+func BenchmarkJSONIterMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := jsoniter.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkJSONIterUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = jsoniter.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}

--- a/output_tests/maps/builtins/uint8/bool/types.go
+++ b/output_tests/maps/builtins/uint8/bool/types.go
@@ -1,0 +1,3 @@
+package test
+
+type T map[uint8]bool

--- a/output_tests/maps/builtins/uint8/byte/json_test.go
+++ b/output_tests/maps/builtins/uint8/byte/json_test.go
@@ -1,0 +1,144 @@
+package test
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/davecgh/go-spew/spew"
+	fuzz "github.com/google/gofuzz"
+	jsoniter "github.com/json-iterator/go"
+)
+
+func Test_Roundtrip(t *testing.T) {
+	fz := fuzz.New().MaxDepth(10).NilChance(0.3)
+	for i := 0; i < 1000; i++ {
+		var before T
+		fz.Fuzz(&before)
+
+		jbStd, err := json.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with stdlib: %v", err)
+		}
+		jbIter, err := jsoniter.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with jsoniter: %v", err)
+		}
+		if string(jbStd) != string(jbIter) {
+			t.Errorf("marshal expected:\n    %s\ngot:\n    %s\nobj:\n    %s",
+				indent(jbStd, "    "), indent(jbIter, "    "), dump(before))
+		}
+
+		var afterStd T
+		err = json.Unmarshal(jbIter, &afterStd)
+		if err != nil {
+			t.Errorf("failed to unmarshal with stdlib: %v", err)
+		}
+		var afterIter T
+		err = jsoniter.Unmarshal(jbIter, &afterIter)
+		if err != nil {
+			t.Errorf("failed to unmarshal with jsoniter: %v", err)
+		}
+		if fingerprint(afterStd) != fingerprint(afterIter) {
+			t.Errorf("unmarshal expected:\n    %s\ngot:\n    %s\nvia:\n    %s",
+				dump(afterStd), dump(afterIter), indent(jbIter, "    "))
+		}
+	}
+}
+
+const indentStr = ">  "
+
+func fingerprint(obj interface{}) string {
+	c := spew.ConfigState{
+		SortKeys: true,
+		SpewKeys: true,
+	}
+	return c.Sprintf("%v", obj)
+}
+
+func dump(obj interface{}) string {
+	cfg := spew.ConfigState{
+		Indent: indentStr,
+	}
+	return cfg.Sdump(obj)
+}
+
+func indent(src []byte, prefix string) string {
+	var buf bytes.Buffer
+	json.Indent(&buf, src, prefix, indentStr)
+	return buf.String()
+}
+
+func BenchmarkStandardMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := json.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkStandardUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = json.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}
+
+func BenchmarkJSONIterMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := jsoniter.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkJSONIterUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = jsoniter.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}

--- a/output_tests/maps/builtins/uint8/byte/types.go
+++ b/output_tests/maps/builtins/uint8/byte/types.go
@@ -1,0 +1,3 @@
+package test
+
+type T map[uint8]byte

--- a/output_tests/maps/builtins/uint8/float32/json_test.go
+++ b/output_tests/maps/builtins/uint8/float32/json_test.go
@@ -1,0 +1,144 @@
+package test
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/davecgh/go-spew/spew"
+	fuzz "github.com/google/gofuzz"
+	jsoniter "github.com/json-iterator/go"
+)
+
+func Test_Roundtrip(t *testing.T) {
+	fz := fuzz.New().MaxDepth(10).NilChance(0.3)
+	for i := 0; i < 1000; i++ {
+		var before T
+		fz.Fuzz(&before)
+
+		jbStd, err := json.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with stdlib: %v", err)
+		}
+		jbIter, err := jsoniter.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with jsoniter: %v", err)
+		}
+		if string(jbStd) != string(jbIter) {
+			t.Errorf("marshal expected:\n    %s\ngot:\n    %s\nobj:\n    %s",
+				indent(jbStd, "    "), indent(jbIter, "    "), dump(before))
+		}
+
+		var afterStd T
+		err = json.Unmarshal(jbIter, &afterStd)
+		if err != nil {
+			t.Errorf("failed to unmarshal with stdlib: %v", err)
+		}
+		var afterIter T
+		err = jsoniter.Unmarshal(jbIter, &afterIter)
+		if err != nil {
+			t.Errorf("failed to unmarshal with jsoniter: %v", err)
+		}
+		if fingerprint(afterStd) != fingerprint(afterIter) {
+			t.Errorf("unmarshal expected:\n    %s\ngot:\n    %s\nvia:\n    %s",
+				dump(afterStd), dump(afterIter), indent(jbIter, "    "))
+		}
+	}
+}
+
+const indentStr = ">  "
+
+func fingerprint(obj interface{}) string {
+	c := spew.ConfigState{
+		SortKeys: true,
+		SpewKeys: true,
+	}
+	return c.Sprintf("%v", obj)
+}
+
+func dump(obj interface{}) string {
+	cfg := spew.ConfigState{
+		Indent: indentStr,
+	}
+	return cfg.Sdump(obj)
+}
+
+func indent(src []byte, prefix string) string {
+	var buf bytes.Buffer
+	json.Indent(&buf, src, prefix, indentStr)
+	return buf.String()
+}
+
+func BenchmarkStandardMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := json.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkStandardUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = json.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}
+
+func BenchmarkJSONIterMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := jsoniter.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkJSONIterUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = jsoniter.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}

--- a/output_tests/maps/builtins/uint8/float32/types.go
+++ b/output_tests/maps/builtins/uint8/float32/types.go
@@ -1,0 +1,3 @@
+package test
+
+type T map[uint8]float32

--- a/output_tests/maps/builtins/uint8/float64/json_test.go
+++ b/output_tests/maps/builtins/uint8/float64/json_test.go
@@ -1,0 +1,144 @@
+package test
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/davecgh/go-spew/spew"
+	fuzz "github.com/google/gofuzz"
+	jsoniter "github.com/json-iterator/go"
+)
+
+func Test_Roundtrip(t *testing.T) {
+	fz := fuzz.New().MaxDepth(10).NilChance(0.3)
+	for i := 0; i < 1000; i++ {
+		var before T
+		fz.Fuzz(&before)
+
+		jbStd, err := json.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with stdlib: %v", err)
+		}
+		jbIter, err := jsoniter.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with jsoniter: %v", err)
+		}
+		if string(jbStd) != string(jbIter) {
+			t.Errorf("marshal expected:\n    %s\ngot:\n    %s\nobj:\n    %s",
+				indent(jbStd, "    "), indent(jbIter, "    "), dump(before))
+		}
+
+		var afterStd T
+		err = json.Unmarshal(jbIter, &afterStd)
+		if err != nil {
+			t.Errorf("failed to unmarshal with stdlib: %v", err)
+		}
+		var afterIter T
+		err = jsoniter.Unmarshal(jbIter, &afterIter)
+		if err != nil {
+			t.Errorf("failed to unmarshal with jsoniter: %v", err)
+		}
+		if fingerprint(afterStd) != fingerprint(afterIter) {
+			t.Errorf("unmarshal expected:\n    %s\ngot:\n    %s\nvia:\n    %s",
+				dump(afterStd), dump(afterIter), indent(jbIter, "    "))
+		}
+	}
+}
+
+const indentStr = ">  "
+
+func fingerprint(obj interface{}) string {
+	c := spew.ConfigState{
+		SortKeys: true,
+		SpewKeys: true,
+	}
+	return c.Sprintf("%v", obj)
+}
+
+func dump(obj interface{}) string {
+	cfg := spew.ConfigState{
+		Indent: indentStr,
+	}
+	return cfg.Sdump(obj)
+}
+
+func indent(src []byte, prefix string) string {
+	var buf bytes.Buffer
+	json.Indent(&buf, src, prefix, indentStr)
+	return buf.String()
+}
+
+func BenchmarkStandardMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := json.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkStandardUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = json.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}
+
+func BenchmarkJSONIterMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := jsoniter.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkJSONIterUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = jsoniter.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}

--- a/output_tests/maps/builtins/uint8/float64/types.go
+++ b/output_tests/maps/builtins/uint8/float64/types.go
@@ -1,0 +1,3 @@
+package test
+
+type T map[uint8]float64

--- a/output_tests/maps/builtins/uint8/int32/json_test.go
+++ b/output_tests/maps/builtins/uint8/int32/json_test.go
@@ -1,0 +1,144 @@
+package test
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/davecgh/go-spew/spew"
+	fuzz "github.com/google/gofuzz"
+	jsoniter "github.com/json-iterator/go"
+)
+
+func Test_Roundtrip(t *testing.T) {
+	fz := fuzz.New().MaxDepth(10).NilChance(0.3)
+	for i := 0; i < 1000; i++ {
+		var before T
+		fz.Fuzz(&before)
+
+		jbStd, err := json.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with stdlib: %v", err)
+		}
+		jbIter, err := jsoniter.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with jsoniter: %v", err)
+		}
+		if string(jbStd) != string(jbIter) {
+			t.Errorf("marshal expected:\n    %s\ngot:\n    %s\nobj:\n    %s",
+				indent(jbStd, "    "), indent(jbIter, "    "), dump(before))
+		}
+
+		var afterStd T
+		err = json.Unmarshal(jbIter, &afterStd)
+		if err != nil {
+			t.Errorf("failed to unmarshal with stdlib: %v", err)
+		}
+		var afterIter T
+		err = jsoniter.Unmarshal(jbIter, &afterIter)
+		if err != nil {
+			t.Errorf("failed to unmarshal with jsoniter: %v", err)
+		}
+		if fingerprint(afterStd) != fingerprint(afterIter) {
+			t.Errorf("unmarshal expected:\n    %s\ngot:\n    %s\nvia:\n    %s",
+				dump(afterStd), dump(afterIter), indent(jbIter, "    "))
+		}
+	}
+}
+
+const indentStr = ">  "
+
+func fingerprint(obj interface{}) string {
+	c := spew.ConfigState{
+		SortKeys: true,
+		SpewKeys: true,
+	}
+	return c.Sprintf("%v", obj)
+}
+
+func dump(obj interface{}) string {
+	cfg := spew.ConfigState{
+		Indent: indentStr,
+	}
+	return cfg.Sdump(obj)
+}
+
+func indent(src []byte, prefix string) string {
+	var buf bytes.Buffer
+	json.Indent(&buf, src, prefix, indentStr)
+	return buf.String()
+}
+
+func BenchmarkStandardMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := json.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkStandardUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = json.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}
+
+func BenchmarkJSONIterMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := jsoniter.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkJSONIterUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = jsoniter.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}

--- a/output_tests/maps/builtins/uint8/int32/types.go
+++ b/output_tests/maps/builtins/uint8/int32/types.go
@@ -1,0 +1,3 @@
+package test
+
+type T map[uint8]int32

--- a/output_tests/maps/builtins/uint8/int8/json_test.go
+++ b/output_tests/maps/builtins/uint8/int8/json_test.go
@@ -1,0 +1,144 @@
+package test
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/davecgh/go-spew/spew"
+	fuzz "github.com/google/gofuzz"
+	jsoniter "github.com/json-iterator/go"
+)
+
+func Test_Roundtrip(t *testing.T) {
+	fz := fuzz.New().MaxDepth(10).NilChance(0.3)
+	for i := 0; i < 1000; i++ {
+		var before T
+		fz.Fuzz(&before)
+
+		jbStd, err := json.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with stdlib: %v", err)
+		}
+		jbIter, err := jsoniter.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with jsoniter: %v", err)
+		}
+		if string(jbStd) != string(jbIter) {
+			t.Errorf("marshal expected:\n    %s\ngot:\n    %s\nobj:\n    %s",
+				indent(jbStd, "    "), indent(jbIter, "    "), dump(before))
+		}
+
+		var afterStd T
+		err = json.Unmarshal(jbIter, &afterStd)
+		if err != nil {
+			t.Errorf("failed to unmarshal with stdlib: %v", err)
+		}
+		var afterIter T
+		err = jsoniter.Unmarshal(jbIter, &afterIter)
+		if err != nil {
+			t.Errorf("failed to unmarshal with jsoniter: %v", err)
+		}
+		if fingerprint(afterStd) != fingerprint(afterIter) {
+			t.Errorf("unmarshal expected:\n    %s\ngot:\n    %s\nvia:\n    %s",
+				dump(afterStd), dump(afterIter), indent(jbIter, "    "))
+		}
+	}
+}
+
+const indentStr = ">  "
+
+func fingerprint(obj interface{}) string {
+	c := spew.ConfigState{
+		SortKeys: true,
+		SpewKeys: true,
+	}
+	return c.Sprintf("%v", obj)
+}
+
+func dump(obj interface{}) string {
+	cfg := spew.ConfigState{
+		Indent: indentStr,
+	}
+	return cfg.Sdump(obj)
+}
+
+func indent(src []byte, prefix string) string {
+	var buf bytes.Buffer
+	json.Indent(&buf, src, prefix, indentStr)
+	return buf.String()
+}
+
+func BenchmarkStandardMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := json.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkStandardUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = json.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}
+
+func BenchmarkJSONIterMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := jsoniter.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkJSONIterUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = jsoniter.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}

--- a/output_tests/maps/builtins/uint8/int8/types.go
+++ b/output_tests/maps/builtins/uint8/int8/types.go
@@ -1,0 +1,3 @@
+package test
+
+type T map[uint8]int8

--- a/output_tests/maps/builtins/uint8/string/json_test.go
+++ b/output_tests/maps/builtins/uint8/string/json_test.go
@@ -1,0 +1,144 @@
+package test
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/davecgh/go-spew/spew"
+	fuzz "github.com/google/gofuzz"
+	jsoniter "github.com/json-iterator/go"
+)
+
+func Test_Roundtrip(t *testing.T) {
+	fz := fuzz.New().MaxDepth(10).NilChance(0.3)
+	for i := 0; i < 1000; i++ {
+		var before T
+		fz.Fuzz(&before)
+
+		jbStd, err := json.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with stdlib: %v", err)
+		}
+		jbIter, err := jsoniter.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with jsoniter: %v", err)
+		}
+		if string(jbStd) != string(jbIter) {
+			t.Errorf("marshal expected:\n    %s\ngot:\n    %s\nobj:\n    %s",
+				indent(jbStd, "    "), indent(jbIter, "    "), dump(before))
+		}
+
+		var afterStd T
+		err = json.Unmarshal(jbIter, &afterStd)
+		if err != nil {
+			t.Errorf("failed to unmarshal with stdlib: %v", err)
+		}
+		var afterIter T
+		err = jsoniter.Unmarshal(jbIter, &afterIter)
+		if err != nil {
+			t.Errorf("failed to unmarshal with jsoniter: %v", err)
+		}
+		if fingerprint(afterStd) != fingerprint(afterIter) {
+			t.Errorf("unmarshal expected:\n    %s\ngot:\n    %s\nvia:\n    %s",
+				dump(afterStd), dump(afterIter), indent(jbIter, "    "))
+		}
+	}
+}
+
+const indentStr = ">  "
+
+func fingerprint(obj interface{}) string {
+	c := spew.ConfigState{
+		SortKeys: true,
+		SpewKeys: true,
+	}
+	return c.Sprintf("%v", obj)
+}
+
+func dump(obj interface{}) string {
+	cfg := spew.ConfigState{
+		Indent: indentStr,
+	}
+	return cfg.Sdump(obj)
+}
+
+func indent(src []byte, prefix string) string {
+	var buf bytes.Buffer
+	json.Indent(&buf, src, prefix, indentStr)
+	return buf.String()
+}
+
+func BenchmarkStandardMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := json.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkStandardUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = json.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}
+
+func BenchmarkJSONIterMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := jsoniter.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkJSONIterUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = jsoniter.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}

--- a/output_tests/maps/builtins/uint8/string/types.go
+++ b/output_tests/maps/builtins/uint8/string/types.go
@@ -1,0 +1,3 @@
+package test
+
+type T map[uint8]string

--- a/output_tests/maps/builtins/uint8/string_alias/json_test.go
+++ b/output_tests/maps/builtins/uint8/string_alias/json_test.go
@@ -1,0 +1,144 @@
+package test
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/davecgh/go-spew/spew"
+	fuzz "github.com/google/gofuzz"
+	jsoniter "github.com/json-iterator/go"
+)
+
+func Test_Roundtrip(t *testing.T) {
+	fz := fuzz.New().MaxDepth(10).NilChance(0.3)
+	for i := 0; i < 1000; i++ {
+		var before T
+		fz.Fuzz(&before)
+
+		jbStd, err := json.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with stdlib: %v", err)
+		}
+		jbIter, err := jsoniter.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with jsoniter: %v", err)
+		}
+		if string(jbStd) != string(jbIter) {
+			t.Errorf("marshal expected:\n    %s\ngot:\n    %s\nobj:\n    %s",
+				indent(jbStd, "    "), indent(jbIter, "    "), dump(before))
+		}
+
+		var afterStd T
+		err = json.Unmarshal(jbIter, &afterStd)
+		if err != nil {
+			t.Errorf("failed to unmarshal with stdlib: %v", err)
+		}
+		var afterIter T
+		err = jsoniter.Unmarshal(jbIter, &afterIter)
+		if err != nil {
+			t.Errorf("failed to unmarshal with jsoniter: %v", err)
+		}
+		if fingerprint(afterStd) != fingerprint(afterIter) {
+			t.Errorf("unmarshal expected:\n    %s\ngot:\n    %s\nvia:\n    %s",
+				dump(afterStd), dump(afterIter), indent(jbIter, "    "))
+		}
+	}
+}
+
+const indentStr = ">  "
+
+func fingerprint(obj interface{}) string {
+	c := spew.ConfigState{
+		SortKeys: true,
+		SpewKeys: true,
+	}
+	return c.Sprintf("%v", obj)
+}
+
+func dump(obj interface{}) string {
+	cfg := spew.ConfigState{
+		Indent: indentStr,
+	}
+	return cfg.Sdump(obj)
+}
+
+func indent(src []byte, prefix string) string {
+	var buf bytes.Buffer
+	json.Indent(&buf, src, prefix, indentStr)
+	return buf.String()
+}
+
+func BenchmarkStandardMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := json.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkStandardUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = json.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}
+
+func BenchmarkJSONIterMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := jsoniter.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkJSONIterUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = jsoniter.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}

--- a/output_tests/maps/builtins/uint8/string_alias/types.go
+++ b/output_tests/maps/builtins/uint8/string_alias/types.go
@@ -1,0 +1,5 @@
+package test
+
+type StringAlias string
+
+type T map[uint8]StringAlias

--- a/output_tests/maps/builtins/uint8/uint8/json_test.go
+++ b/output_tests/maps/builtins/uint8/uint8/json_test.go
@@ -1,0 +1,144 @@
+package test
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/davecgh/go-spew/spew"
+	fuzz "github.com/google/gofuzz"
+	jsoniter "github.com/json-iterator/go"
+)
+
+func Test_Roundtrip(t *testing.T) {
+	fz := fuzz.New().MaxDepth(10).NilChance(0.3)
+	for i := 0; i < 1000; i++ {
+		var before T
+		fz.Fuzz(&before)
+
+		jbStd, err := json.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with stdlib: %v", err)
+		}
+		jbIter, err := jsoniter.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with jsoniter: %v", err)
+		}
+		if string(jbStd) != string(jbIter) {
+			t.Errorf("marshal expected:\n    %s\ngot:\n    %s\nobj:\n    %s",
+				indent(jbStd, "    "), indent(jbIter, "    "), dump(before))
+		}
+
+		var afterStd T
+		err = json.Unmarshal(jbIter, &afterStd)
+		if err != nil {
+			t.Errorf("failed to unmarshal with stdlib: %v", err)
+		}
+		var afterIter T
+		err = jsoniter.Unmarshal(jbIter, &afterIter)
+		if err != nil {
+			t.Errorf("failed to unmarshal with jsoniter: %v", err)
+		}
+		if fingerprint(afterStd) != fingerprint(afterIter) {
+			t.Errorf("unmarshal expected:\n    %s\ngot:\n    %s\nvia:\n    %s",
+				dump(afterStd), dump(afterIter), indent(jbIter, "    "))
+		}
+	}
+}
+
+const indentStr = ">  "
+
+func fingerprint(obj interface{}) string {
+	c := spew.ConfigState{
+		SortKeys: true,
+		SpewKeys: true,
+	}
+	return c.Sprintf("%v", obj)
+}
+
+func dump(obj interface{}) string {
+	cfg := spew.ConfigState{
+		Indent: indentStr,
+	}
+	return cfg.Sdump(obj)
+}
+
+func indent(src []byte, prefix string) string {
+	var buf bytes.Buffer
+	json.Indent(&buf, src, prefix, indentStr)
+	return buf.String()
+}
+
+func BenchmarkStandardMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := json.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkStandardUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = json.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}
+
+func BenchmarkJSONIterMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := jsoniter.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkJSONIterUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = jsoniter.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}

--- a/output_tests/maps/builtins/uint8/uint8/types.go
+++ b/output_tests/maps/builtins/uint8/uint8/types.go
@@ -1,0 +1,3 @@
+package test
+
+type T map[uint8]uint8

--- a/output_tests/maps/pointers/int16/ptr_bool/json_test.go
+++ b/output_tests/maps/pointers/int16/ptr_bool/json_test.go
@@ -1,0 +1,144 @@
+package test
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/davecgh/go-spew/spew"
+	fuzz "github.com/google/gofuzz"
+	jsoniter "github.com/json-iterator/go"
+)
+
+func Test_Roundtrip(t *testing.T) {
+	fz := fuzz.New().MaxDepth(10).NilChance(0.3)
+	for i := 0; i < 1000; i++ {
+		var before T
+		fz.Fuzz(&before)
+
+		jbStd, err := json.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with stdlib: %v", err)
+		}
+		jbIter, err := jsoniter.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with jsoniter: %v", err)
+		}
+		if string(jbStd) != string(jbIter) {
+			t.Errorf("marshal expected:\n    %s\ngot:\n    %s\nobj:\n    %s",
+				indent(jbStd, "    "), indent(jbIter, "    "), dump(before))
+		}
+
+		var afterStd T
+		err = json.Unmarshal(jbIter, &afterStd)
+		if err != nil {
+			t.Errorf("failed to unmarshal with stdlib: %v", err)
+		}
+		var afterIter T
+		err = jsoniter.Unmarshal(jbIter, &afterIter)
+		if err != nil {
+			t.Errorf("failed to unmarshal with jsoniter: %v", err)
+		}
+		if fingerprint(afterStd) != fingerprint(afterIter) {
+			t.Errorf("unmarshal expected:\n    %s\ngot:\n    %s\nvia:\n    %s",
+				dump(afterStd), dump(afterIter), indent(jbIter, "    "))
+		}
+	}
+}
+
+const indentStr = ">  "
+
+func fingerprint(obj interface{}) string {
+	c := spew.ConfigState{
+		SortKeys: true,
+		SpewKeys: true,
+	}
+	return c.Sprintf("%v", obj)
+}
+
+func dump(obj interface{}) string {
+	cfg := spew.ConfigState{
+		Indent: indentStr,
+	}
+	return cfg.Sdump(obj)
+}
+
+func indent(src []byte, prefix string) string {
+	var buf bytes.Buffer
+	json.Indent(&buf, src, prefix, indentStr)
+	return buf.String()
+}
+
+func BenchmarkStandardMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := json.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkStandardUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = json.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}
+
+func BenchmarkJSONIterMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := jsoniter.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkJSONIterUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = jsoniter.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}

--- a/output_tests/maps/pointers/int16/ptr_bool/types.go
+++ b/output_tests/maps/pointers/int16/ptr_bool/types.go
@@ -1,0 +1,3 @@
+package test
+
+type T map[int16]*bool

--- a/output_tests/maps/pointers/int16/ptr_float64/json_test.go
+++ b/output_tests/maps/pointers/int16/ptr_float64/json_test.go
@@ -1,0 +1,144 @@
+package test
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/davecgh/go-spew/spew"
+	fuzz "github.com/google/gofuzz"
+	jsoniter "github.com/json-iterator/go"
+)
+
+func Test_Roundtrip(t *testing.T) {
+	fz := fuzz.New().MaxDepth(10).NilChance(0.3)
+	for i := 0; i < 1000; i++ {
+		var before T
+		fz.Fuzz(&before)
+
+		jbStd, err := json.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with stdlib: %v", err)
+		}
+		jbIter, err := jsoniter.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with jsoniter: %v", err)
+		}
+		if string(jbStd) != string(jbIter) {
+			t.Errorf("marshal expected:\n    %s\ngot:\n    %s\nobj:\n    %s",
+				indent(jbStd, "    "), indent(jbIter, "    "), dump(before))
+		}
+
+		var afterStd T
+		err = json.Unmarshal(jbIter, &afterStd)
+		if err != nil {
+			t.Errorf("failed to unmarshal with stdlib: %v", err)
+		}
+		var afterIter T
+		err = jsoniter.Unmarshal(jbIter, &afterIter)
+		if err != nil {
+			t.Errorf("failed to unmarshal with jsoniter: %v", err)
+		}
+		if fingerprint(afterStd) != fingerprint(afterIter) {
+			t.Errorf("unmarshal expected:\n    %s\ngot:\n    %s\nvia:\n    %s",
+				dump(afterStd), dump(afterIter), indent(jbIter, "    "))
+		}
+	}
+}
+
+const indentStr = ">  "
+
+func fingerprint(obj interface{}) string {
+	c := spew.ConfigState{
+		SortKeys: true,
+		SpewKeys: true,
+	}
+	return c.Sprintf("%v", obj)
+}
+
+func dump(obj interface{}) string {
+	cfg := spew.ConfigState{
+		Indent: indentStr,
+	}
+	return cfg.Sdump(obj)
+}
+
+func indent(src []byte, prefix string) string {
+	var buf bytes.Buffer
+	json.Indent(&buf, src, prefix, indentStr)
+	return buf.String()
+}
+
+func BenchmarkStandardMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := json.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkStandardUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = json.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}
+
+func BenchmarkJSONIterMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := jsoniter.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkJSONIterUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = jsoniter.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}

--- a/output_tests/maps/pointers/int16/ptr_float64/types.go
+++ b/output_tests/maps/pointers/int16/ptr_float64/types.go
@@ -1,0 +1,3 @@
+package test
+
+type T map[int16]*float64

--- a/output_tests/maps/pointers/int16/ptr_int32/json_test.go
+++ b/output_tests/maps/pointers/int16/ptr_int32/json_test.go
@@ -1,0 +1,144 @@
+package test
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/davecgh/go-spew/spew"
+	fuzz "github.com/google/gofuzz"
+	jsoniter "github.com/json-iterator/go"
+)
+
+func Test_Roundtrip(t *testing.T) {
+	fz := fuzz.New().MaxDepth(10).NilChance(0.3)
+	for i := 0; i < 1000; i++ {
+		var before T
+		fz.Fuzz(&before)
+
+		jbStd, err := json.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with stdlib: %v", err)
+		}
+		jbIter, err := jsoniter.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with jsoniter: %v", err)
+		}
+		if string(jbStd) != string(jbIter) {
+			t.Errorf("marshal expected:\n    %s\ngot:\n    %s\nobj:\n    %s",
+				indent(jbStd, "    "), indent(jbIter, "    "), dump(before))
+		}
+
+		var afterStd T
+		err = json.Unmarshal(jbIter, &afterStd)
+		if err != nil {
+			t.Errorf("failed to unmarshal with stdlib: %v", err)
+		}
+		var afterIter T
+		err = jsoniter.Unmarshal(jbIter, &afterIter)
+		if err != nil {
+			t.Errorf("failed to unmarshal with jsoniter: %v", err)
+		}
+		if fingerprint(afterStd) != fingerprint(afterIter) {
+			t.Errorf("unmarshal expected:\n    %s\ngot:\n    %s\nvia:\n    %s",
+				dump(afterStd), dump(afterIter), indent(jbIter, "    "))
+		}
+	}
+}
+
+const indentStr = ">  "
+
+func fingerprint(obj interface{}) string {
+	c := spew.ConfigState{
+		SortKeys: true,
+		SpewKeys: true,
+	}
+	return c.Sprintf("%v", obj)
+}
+
+func dump(obj interface{}) string {
+	cfg := spew.ConfigState{
+		Indent: indentStr,
+	}
+	return cfg.Sdump(obj)
+}
+
+func indent(src []byte, prefix string) string {
+	var buf bytes.Buffer
+	json.Indent(&buf, src, prefix, indentStr)
+	return buf.String()
+}
+
+func BenchmarkStandardMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := json.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkStandardUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = json.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}
+
+func BenchmarkJSONIterMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := jsoniter.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkJSONIterUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = jsoniter.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}

--- a/output_tests/maps/pointers/int16/ptr_int32/types.go
+++ b/output_tests/maps/pointers/int16/ptr_int32/types.go
@@ -1,0 +1,3 @@
+package test
+
+type T map[int16]*int32

--- a/output_tests/maps/pointers/int16/ptr_string/json_test.go
+++ b/output_tests/maps/pointers/int16/ptr_string/json_test.go
@@ -1,0 +1,144 @@
+package test
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/davecgh/go-spew/spew"
+	fuzz "github.com/google/gofuzz"
+	jsoniter "github.com/json-iterator/go"
+)
+
+func Test_Roundtrip(t *testing.T) {
+	fz := fuzz.New().MaxDepth(10).NilChance(0.3)
+	for i := 0; i < 1000; i++ {
+		var before T
+		fz.Fuzz(&before)
+
+		jbStd, err := json.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with stdlib: %v", err)
+		}
+		jbIter, err := jsoniter.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with jsoniter: %v", err)
+		}
+		if string(jbStd) != string(jbIter) {
+			t.Errorf("marshal expected:\n    %s\ngot:\n    %s\nobj:\n    %s",
+				indent(jbStd, "    "), indent(jbIter, "    "), dump(before))
+		}
+
+		var afterStd T
+		err = json.Unmarshal(jbIter, &afterStd)
+		if err != nil {
+			t.Errorf("failed to unmarshal with stdlib: %v", err)
+		}
+		var afterIter T
+		err = jsoniter.Unmarshal(jbIter, &afterIter)
+		if err != nil {
+			t.Errorf("failed to unmarshal with jsoniter: %v", err)
+		}
+		if fingerprint(afterStd) != fingerprint(afterIter) {
+			t.Errorf("unmarshal expected:\n    %s\ngot:\n    %s\nvia:\n    %s",
+				dump(afterStd), dump(afterIter), indent(jbIter, "    "))
+		}
+	}
+}
+
+const indentStr = ">  "
+
+func fingerprint(obj interface{}) string {
+	c := spew.ConfigState{
+		SortKeys: true,
+		SpewKeys: true,
+	}
+	return c.Sprintf("%v", obj)
+}
+
+func dump(obj interface{}) string {
+	cfg := spew.ConfigState{
+		Indent: indentStr,
+	}
+	return cfg.Sdump(obj)
+}
+
+func indent(src []byte, prefix string) string {
+	var buf bytes.Buffer
+	json.Indent(&buf, src, prefix, indentStr)
+	return buf.String()
+}
+
+func BenchmarkStandardMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := json.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkStandardUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = json.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}
+
+func BenchmarkJSONIterMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := jsoniter.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkJSONIterUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = jsoniter.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}

--- a/output_tests/maps/pointers/int16/ptr_string/types.go
+++ b/output_tests/maps/pointers/int16/ptr_string/types.go
@@ -1,0 +1,3 @@
+package test
+
+type T map[int16]*string

--- a/output_tests/maps/pointers/int16/ptr_uint8/json_test.go
+++ b/output_tests/maps/pointers/int16/ptr_uint8/json_test.go
@@ -1,0 +1,144 @@
+package test
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/davecgh/go-spew/spew"
+	fuzz "github.com/google/gofuzz"
+	jsoniter "github.com/json-iterator/go"
+)
+
+func Test_Roundtrip(t *testing.T) {
+	fz := fuzz.New().MaxDepth(10).NilChance(0.3)
+	for i := 0; i < 1000; i++ {
+		var before T
+		fz.Fuzz(&before)
+
+		jbStd, err := json.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with stdlib: %v", err)
+		}
+		jbIter, err := jsoniter.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with jsoniter: %v", err)
+		}
+		if string(jbStd) != string(jbIter) {
+			t.Errorf("marshal expected:\n    %s\ngot:\n    %s\nobj:\n    %s",
+				indent(jbStd, "    "), indent(jbIter, "    "), dump(before))
+		}
+
+		var afterStd T
+		err = json.Unmarshal(jbIter, &afterStd)
+		if err != nil {
+			t.Errorf("failed to unmarshal with stdlib: %v", err)
+		}
+		var afterIter T
+		err = jsoniter.Unmarshal(jbIter, &afterIter)
+		if err != nil {
+			t.Errorf("failed to unmarshal with jsoniter: %v", err)
+		}
+		if fingerprint(afterStd) != fingerprint(afterIter) {
+			t.Errorf("unmarshal expected:\n    %s\ngot:\n    %s\nvia:\n    %s",
+				dump(afterStd), dump(afterIter), indent(jbIter, "    "))
+		}
+	}
+}
+
+const indentStr = ">  "
+
+func fingerprint(obj interface{}) string {
+	c := spew.ConfigState{
+		SortKeys: true,
+		SpewKeys: true,
+	}
+	return c.Sprintf("%v", obj)
+}
+
+func dump(obj interface{}) string {
+	cfg := spew.ConfigState{
+		Indent: indentStr,
+	}
+	return cfg.Sdump(obj)
+}
+
+func indent(src []byte, prefix string) string {
+	var buf bytes.Buffer
+	json.Indent(&buf, src, prefix, indentStr)
+	return buf.String()
+}
+
+func BenchmarkStandardMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := json.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkStandardUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = json.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}
+
+func BenchmarkJSONIterMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := jsoniter.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkJSONIterUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = jsoniter.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}

--- a/output_tests/maps/pointers/int16/ptr_uint8/types.go
+++ b/output_tests/maps/pointers/int16/ptr_uint8/types.go
@@ -1,0 +1,3 @@
+package test
+
+type T map[int16]*uint8

--- a/output_tests/maps/pointers/string/ptr_bool/json_test.go
+++ b/output_tests/maps/pointers/string/ptr_bool/json_test.go
@@ -1,0 +1,144 @@
+package test
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/davecgh/go-spew/spew"
+	fuzz "github.com/google/gofuzz"
+	jsoniter "github.com/json-iterator/go"
+)
+
+func Test_Roundtrip(t *testing.T) {
+	fz := fuzz.New().MaxDepth(10).NilChance(0.3)
+	for i := 0; i < 1000; i++ {
+		var before T
+		fz.Fuzz(&before)
+
+		jbStd, err := json.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with stdlib: %v", err)
+		}
+		jbIter, err := jsoniter.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with jsoniter: %v", err)
+		}
+		if string(jbStd) != string(jbIter) {
+			t.Errorf("marshal expected:\n    %s\ngot:\n    %s\nobj:\n    %s",
+				indent(jbStd, "    "), indent(jbIter, "    "), dump(before))
+		}
+
+		var afterStd T
+		err = json.Unmarshal(jbIter, &afterStd)
+		if err != nil {
+			t.Errorf("failed to unmarshal with stdlib: %v", err)
+		}
+		var afterIter T
+		err = jsoniter.Unmarshal(jbIter, &afterIter)
+		if err != nil {
+			t.Errorf("failed to unmarshal with jsoniter: %v", err)
+		}
+		if fingerprint(afterStd) != fingerprint(afterIter) {
+			t.Errorf("unmarshal expected:\n    %s\ngot:\n    %s\nvia:\n    %s",
+				dump(afterStd), dump(afterIter), indent(jbIter, "    "))
+		}
+	}
+}
+
+const indentStr = ">  "
+
+func fingerprint(obj interface{}) string {
+	c := spew.ConfigState{
+		SortKeys: true,
+		SpewKeys: true,
+	}
+	return c.Sprintf("%v", obj)
+}
+
+func dump(obj interface{}) string {
+	cfg := spew.ConfigState{
+		Indent: indentStr,
+	}
+	return cfg.Sdump(obj)
+}
+
+func indent(src []byte, prefix string) string {
+	var buf bytes.Buffer
+	json.Indent(&buf, src, prefix, indentStr)
+	return buf.String()
+}
+
+func BenchmarkStandardMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := json.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkStandardUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = json.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}
+
+func BenchmarkJSONIterMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := jsoniter.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkJSONIterUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = jsoniter.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}

--- a/output_tests/maps/pointers/string/ptr_bool/types.go
+++ b/output_tests/maps/pointers/string/ptr_bool/types.go
@@ -1,0 +1,3 @@
+package test
+
+type T map[string]*bool

--- a/output_tests/maps/pointers/string/ptr_float64/json_test.go
+++ b/output_tests/maps/pointers/string/ptr_float64/json_test.go
@@ -1,0 +1,144 @@
+package test
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/davecgh/go-spew/spew"
+	fuzz "github.com/google/gofuzz"
+	jsoniter "github.com/json-iterator/go"
+)
+
+func Test_Roundtrip(t *testing.T) {
+	fz := fuzz.New().MaxDepth(10).NilChance(0.3)
+	for i := 0; i < 1000; i++ {
+		var before T
+		fz.Fuzz(&before)
+
+		jbStd, err := json.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with stdlib: %v", err)
+		}
+		jbIter, err := jsoniter.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with jsoniter: %v", err)
+		}
+		if string(jbStd) != string(jbIter) {
+			t.Errorf("marshal expected:\n    %s\ngot:\n    %s\nobj:\n    %s",
+				indent(jbStd, "    "), indent(jbIter, "    "), dump(before))
+		}
+
+		var afterStd T
+		err = json.Unmarshal(jbIter, &afterStd)
+		if err != nil {
+			t.Errorf("failed to unmarshal with stdlib: %v", err)
+		}
+		var afterIter T
+		err = jsoniter.Unmarshal(jbIter, &afterIter)
+		if err != nil {
+			t.Errorf("failed to unmarshal with jsoniter: %v", err)
+		}
+		if fingerprint(afterStd) != fingerprint(afterIter) {
+			t.Errorf("unmarshal expected:\n    %s\ngot:\n    %s\nvia:\n    %s",
+				dump(afterStd), dump(afterIter), indent(jbIter, "    "))
+		}
+	}
+}
+
+const indentStr = ">  "
+
+func fingerprint(obj interface{}) string {
+	c := spew.ConfigState{
+		SortKeys: true,
+		SpewKeys: true,
+	}
+	return c.Sprintf("%v", obj)
+}
+
+func dump(obj interface{}) string {
+	cfg := spew.ConfigState{
+		Indent: indentStr,
+	}
+	return cfg.Sdump(obj)
+}
+
+func indent(src []byte, prefix string) string {
+	var buf bytes.Buffer
+	json.Indent(&buf, src, prefix, indentStr)
+	return buf.String()
+}
+
+func BenchmarkStandardMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := json.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkStandardUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = json.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}
+
+func BenchmarkJSONIterMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := jsoniter.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkJSONIterUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = jsoniter.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}

--- a/output_tests/maps/pointers/string/ptr_float64/types.go
+++ b/output_tests/maps/pointers/string/ptr_float64/types.go
@@ -1,0 +1,3 @@
+package test
+
+type T map[string]*float64

--- a/output_tests/maps/pointers/string/ptr_int32/json_test.go
+++ b/output_tests/maps/pointers/string/ptr_int32/json_test.go
@@ -1,0 +1,144 @@
+package test
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/davecgh/go-spew/spew"
+	fuzz "github.com/google/gofuzz"
+	jsoniter "github.com/json-iterator/go"
+)
+
+func Test_Roundtrip(t *testing.T) {
+	fz := fuzz.New().MaxDepth(10).NilChance(0.3)
+	for i := 0; i < 1000; i++ {
+		var before T
+		fz.Fuzz(&before)
+
+		jbStd, err := json.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with stdlib: %v", err)
+		}
+		jbIter, err := jsoniter.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with jsoniter: %v", err)
+		}
+		if string(jbStd) != string(jbIter) {
+			t.Errorf("marshal expected:\n    %s\ngot:\n    %s\nobj:\n    %s",
+				indent(jbStd, "    "), indent(jbIter, "    "), dump(before))
+		}
+
+		var afterStd T
+		err = json.Unmarshal(jbIter, &afterStd)
+		if err != nil {
+			t.Errorf("failed to unmarshal with stdlib: %v", err)
+		}
+		var afterIter T
+		err = jsoniter.Unmarshal(jbIter, &afterIter)
+		if err != nil {
+			t.Errorf("failed to unmarshal with jsoniter: %v", err)
+		}
+		if fingerprint(afterStd) != fingerprint(afterIter) {
+			t.Errorf("unmarshal expected:\n    %s\ngot:\n    %s\nvia:\n    %s",
+				dump(afterStd), dump(afterIter), indent(jbIter, "    "))
+		}
+	}
+}
+
+const indentStr = ">  "
+
+func fingerprint(obj interface{}) string {
+	c := spew.ConfigState{
+		SortKeys: true,
+		SpewKeys: true,
+	}
+	return c.Sprintf("%v", obj)
+}
+
+func dump(obj interface{}) string {
+	cfg := spew.ConfigState{
+		Indent: indentStr,
+	}
+	return cfg.Sdump(obj)
+}
+
+func indent(src []byte, prefix string) string {
+	var buf bytes.Buffer
+	json.Indent(&buf, src, prefix, indentStr)
+	return buf.String()
+}
+
+func BenchmarkStandardMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := json.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkStandardUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = json.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}
+
+func BenchmarkJSONIterMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := jsoniter.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkJSONIterUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = jsoniter.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}

--- a/output_tests/maps/pointers/string/ptr_int32/types.go
+++ b/output_tests/maps/pointers/string/ptr_int32/types.go
@@ -1,0 +1,3 @@
+package test
+
+type T map[string]*int32

--- a/output_tests/maps/pointers/string/ptr_string/json_test.go
+++ b/output_tests/maps/pointers/string/ptr_string/json_test.go
@@ -1,0 +1,144 @@
+package test
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/davecgh/go-spew/spew"
+	fuzz "github.com/google/gofuzz"
+	jsoniter "github.com/json-iterator/go"
+)
+
+func Test_Roundtrip(t *testing.T) {
+	fz := fuzz.New().MaxDepth(10).NilChance(0.3)
+	for i := 0; i < 1000; i++ {
+		var before T
+		fz.Fuzz(&before)
+
+		jbStd, err := json.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with stdlib: %v", err)
+		}
+		jbIter, err := jsoniter.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with jsoniter: %v", err)
+		}
+		if string(jbStd) != string(jbIter) {
+			t.Errorf("marshal expected:\n    %s\ngot:\n    %s\nobj:\n    %s",
+				indent(jbStd, "    "), indent(jbIter, "    "), dump(before))
+		}
+
+		var afterStd T
+		err = json.Unmarshal(jbIter, &afterStd)
+		if err != nil {
+			t.Errorf("failed to unmarshal with stdlib: %v", err)
+		}
+		var afterIter T
+		err = jsoniter.Unmarshal(jbIter, &afterIter)
+		if err != nil {
+			t.Errorf("failed to unmarshal with jsoniter: %v", err)
+		}
+		if fingerprint(afterStd) != fingerprint(afterIter) {
+			t.Errorf("unmarshal expected:\n    %s\ngot:\n    %s\nvia:\n    %s",
+				dump(afterStd), dump(afterIter), indent(jbIter, "    "))
+		}
+	}
+}
+
+const indentStr = ">  "
+
+func fingerprint(obj interface{}) string {
+	c := spew.ConfigState{
+		SortKeys: true,
+		SpewKeys: true,
+	}
+	return c.Sprintf("%v", obj)
+}
+
+func dump(obj interface{}) string {
+	cfg := spew.ConfigState{
+		Indent: indentStr,
+	}
+	return cfg.Sdump(obj)
+}
+
+func indent(src []byte, prefix string) string {
+	var buf bytes.Buffer
+	json.Indent(&buf, src, prefix, indentStr)
+	return buf.String()
+}
+
+func BenchmarkStandardMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := json.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkStandardUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = json.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}
+
+func BenchmarkJSONIterMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := jsoniter.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkJSONIterUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = jsoniter.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}

--- a/output_tests/maps/pointers/string/ptr_string/types.go
+++ b/output_tests/maps/pointers/string/ptr_string/types.go
@@ -1,0 +1,3 @@
+package test
+
+type T map[string]*string

--- a/output_tests/maps/pointers/string/ptr_uint8/json_test.go
+++ b/output_tests/maps/pointers/string/ptr_uint8/json_test.go
@@ -1,0 +1,144 @@
+package test
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/davecgh/go-spew/spew"
+	fuzz "github.com/google/gofuzz"
+	jsoniter "github.com/json-iterator/go"
+)
+
+func Test_Roundtrip(t *testing.T) {
+	fz := fuzz.New().MaxDepth(10).NilChance(0.3)
+	for i := 0; i < 1000; i++ {
+		var before T
+		fz.Fuzz(&before)
+
+		jbStd, err := json.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with stdlib: %v", err)
+		}
+		jbIter, err := jsoniter.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with jsoniter: %v", err)
+		}
+		if string(jbStd) != string(jbIter) {
+			t.Errorf("marshal expected:\n    %s\ngot:\n    %s\nobj:\n    %s",
+				indent(jbStd, "    "), indent(jbIter, "    "), dump(before))
+		}
+
+		var afterStd T
+		err = json.Unmarshal(jbIter, &afterStd)
+		if err != nil {
+			t.Errorf("failed to unmarshal with stdlib: %v", err)
+		}
+		var afterIter T
+		err = jsoniter.Unmarshal(jbIter, &afterIter)
+		if err != nil {
+			t.Errorf("failed to unmarshal with jsoniter: %v", err)
+		}
+		if fingerprint(afterStd) != fingerprint(afterIter) {
+			t.Errorf("unmarshal expected:\n    %s\ngot:\n    %s\nvia:\n    %s",
+				dump(afterStd), dump(afterIter), indent(jbIter, "    "))
+		}
+	}
+}
+
+const indentStr = ">  "
+
+func fingerprint(obj interface{}) string {
+	c := spew.ConfigState{
+		SortKeys: true,
+		SpewKeys: true,
+	}
+	return c.Sprintf("%v", obj)
+}
+
+func dump(obj interface{}) string {
+	cfg := spew.ConfigState{
+		Indent: indentStr,
+	}
+	return cfg.Sdump(obj)
+}
+
+func indent(src []byte, prefix string) string {
+	var buf bytes.Buffer
+	json.Indent(&buf, src, prefix, indentStr)
+	return buf.String()
+}
+
+func BenchmarkStandardMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := json.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkStandardUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = json.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}
+
+func BenchmarkJSONIterMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := jsoniter.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkJSONIterUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = jsoniter.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}

--- a/output_tests/maps/pointers/string/ptr_uint8/types.go
+++ b/output_tests/maps/pointers/string/ptr_uint8/types.go
@@ -1,0 +1,3 @@
+package test
+
+type T map[string]*uint8

--- a/output_tests/maps/pointers/uint16/ptr_bool/json_test.go
+++ b/output_tests/maps/pointers/uint16/ptr_bool/json_test.go
@@ -1,0 +1,144 @@
+package test
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/davecgh/go-spew/spew"
+	fuzz "github.com/google/gofuzz"
+	jsoniter "github.com/json-iterator/go"
+)
+
+func Test_Roundtrip(t *testing.T) {
+	fz := fuzz.New().MaxDepth(10).NilChance(0.3)
+	for i := 0; i < 1000; i++ {
+		var before T
+		fz.Fuzz(&before)
+
+		jbStd, err := json.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with stdlib: %v", err)
+		}
+		jbIter, err := jsoniter.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with jsoniter: %v", err)
+		}
+		if string(jbStd) != string(jbIter) {
+			t.Errorf("marshal expected:\n    %s\ngot:\n    %s\nobj:\n    %s",
+				indent(jbStd, "    "), indent(jbIter, "    "), dump(before))
+		}
+
+		var afterStd T
+		err = json.Unmarshal(jbIter, &afterStd)
+		if err != nil {
+			t.Errorf("failed to unmarshal with stdlib: %v", err)
+		}
+		var afterIter T
+		err = jsoniter.Unmarshal(jbIter, &afterIter)
+		if err != nil {
+			t.Errorf("failed to unmarshal with jsoniter: %v", err)
+		}
+		if fingerprint(afterStd) != fingerprint(afterIter) {
+			t.Errorf("unmarshal expected:\n    %s\ngot:\n    %s\nvia:\n    %s",
+				dump(afterStd), dump(afterIter), indent(jbIter, "    "))
+		}
+	}
+}
+
+const indentStr = ">  "
+
+func fingerprint(obj interface{}) string {
+	c := spew.ConfigState{
+		SortKeys: true,
+		SpewKeys: true,
+	}
+	return c.Sprintf("%v", obj)
+}
+
+func dump(obj interface{}) string {
+	cfg := spew.ConfigState{
+		Indent: indentStr,
+	}
+	return cfg.Sdump(obj)
+}
+
+func indent(src []byte, prefix string) string {
+	var buf bytes.Buffer
+	json.Indent(&buf, src, prefix, indentStr)
+	return buf.String()
+}
+
+func BenchmarkStandardMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := json.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkStandardUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = json.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}
+
+func BenchmarkJSONIterMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := jsoniter.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkJSONIterUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = jsoniter.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}

--- a/output_tests/maps/pointers/uint16/ptr_bool/types.go
+++ b/output_tests/maps/pointers/uint16/ptr_bool/types.go
@@ -1,0 +1,3 @@
+package test
+
+type T map[uint16]*bool

--- a/output_tests/maps/pointers/uint16/ptr_float64/json_test.go
+++ b/output_tests/maps/pointers/uint16/ptr_float64/json_test.go
@@ -1,0 +1,144 @@
+package test
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/davecgh/go-spew/spew"
+	fuzz "github.com/google/gofuzz"
+	jsoniter "github.com/json-iterator/go"
+)
+
+func Test_Roundtrip(t *testing.T) {
+	fz := fuzz.New().MaxDepth(10).NilChance(0.3)
+	for i := 0; i < 1000; i++ {
+		var before T
+		fz.Fuzz(&before)
+
+		jbStd, err := json.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with stdlib: %v", err)
+		}
+		jbIter, err := jsoniter.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with jsoniter: %v", err)
+		}
+		if string(jbStd) != string(jbIter) {
+			t.Errorf("marshal expected:\n    %s\ngot:\n    %s\nobj:\n    %s",
+				indent(jbStd, "    "), indent(jbIter, "    "), dump(before))
+		}
+
+		var afterStd T
+		err = json.Unmarshal(jbIter, &afterStd)
+		if err != nil {
+			t.Errorf("failed to unmarshal with stdlib: %v", err)
+		}
+		var afterIter T
+		err = jsoniter.Unmarshal(jbIter, &afterIter)
+		if err != nil {
+			t.Errorf("failed to unmarshal with jsoniter: %v", err)
+		}
+		if fingerprint(afterStd) != fingerprint(afterIter) {
+			t.Errorf("unmarshal expected:\n    %s\ngot:\n    %s\nvia:\n    %s",
+				dump(afterStd), dump(afterIter), indent(jbIter, "    "))
+		}
+	}
+}
+
+const indentStr = ">  "
+
+func fingerprint(obj interface{}) string {
+	c := spew.ConfigState{
+		SortKeys: true,
+		SpewKeys: true,
+	}
+	return c.Sprintf("%v", obj)
+}
+
+func dump(obj interface{}) string {
+	cfg := spew.ConfigState{
+		Indent: indentStr,
+	}
+	return cfg.Sdump(obj)
+}
+
+func indent(src []byte, prefix string) string {
+	var buf bytes.Buffer
+	json.Indent(&buf, src, prefix, indentStr)
+	return buf.String()
+}
+
+func BenchmarkStandardMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := json.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkStandardUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = json.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}
+
+func BenchmarkJSONIterMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := jsoniter.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkJSONIterUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = jsoniter.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}

--- a/output_tests/maps/pointers/uint16/ptr_float64/types.go
+++ b/output_tests/maps/pointers/uint16/ptr_float64/types.go
@@ -1,0 +1,3 @@
+package test
+
+type T map[uint16]*float64

--- a/output_tests/maps/pointers/uint16/ptr_int32/json_test.go
+++ b/output_tests/maps/pointers/uint16/ptr_int32/json_test.go
@@ -1,0 +1,144 @@
+package test
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/davecgh/go-spew/spew"
+	fuzz "github.com/google/gofuzz"
+	jsoniter "github.com/json-iterator/go"
+)
+
+func Test_Roundtrip(t *testing.T) {
+	fz := fuzz.New().MaxDepth(10).NilChance(0.3)
+	for i := 0; i < 1000; i++ {
+		var before T
+		fz.Fuzz(&before)
+
+		jbStd, err := json.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with stdlib: %v", err)
+		}
+		jbIter, err := jsoniter.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with jsoniter: %v", err)
+		}
+		if string(jbStd) != string(jbIter) {
+			t.Errorf("marshal expected:\n    %s\ngot:\n    %s\nobj:\n    %s",
+				indent(jbStd, "    "), indent(jbIter, "    "), dump(before))
+		}
+
+		var afterStd T
+		err = json.Unmarshal(jbIter, &afterStd)
+		if err != nil {
+			t.Errorf("failed to unmarshal with stdlib: %v", err)
+		}
+		var afterIter T
+		err = jsoniter.Unmarshal(jbIter, &afterIter)
+		if err != nil {
+			t.Errorf("failed to unmarshal with jsoniter: %v", err)
+		}
+		if fingerprint(afterStd) != fingerprint(afterIter) {
+			t.Errorf("unmarshal expected:\n    %s\ngot:\n    %s\nvia:\n    %s",
+				dump(afterStd), dump(afterIter), indent(jbIter, "    "))
+		}
+	}
+}
+
+const indentStr = ">  "
+
+func fingerprint(obj interface{}) string {
+	c := spew.ConfigState{
+		SortKeys: true,
+		SpewKeys: true,
+	}
+	return c.Sprintf("%v", obj)
+}
+
+func dump(obj interface{}) string {
+	cfg := spew.ConfigState{
+		Indent: indentStr,
+	}
+	return cfg.Sdump(obj)
+}
+
+func indent(src []byte, prefix string) string {
+	var buf bytes.Buffer
+	json.Indent(&buf, src, prefix, indentStr)
+	return buf.String()
+}
+
+func BenchmarkStandardMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := json.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkStandardUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = json.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}
+
+func BenchmarkJSONIterMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := jsoniter.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkJSONIterUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = jsoniter.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}

--- a/output_tests/maps/pointers/uint16/ptr_int32/types.go
+++ b/output_tests/maps/pointers/uint16/ptr_int32/types.go
@@ -1,0 +1,3 @@
+package test
+
+type T map[uint16]*int32

--- a/output_tests/maps/pointers/uint16/ptr_string/json_test.go
+++ b/output_tests/maps/pointers/uint16/ptr_string/json_test.go
@@ -1,0 +1,144 @@
+package test
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/davecgh/go-spew/spew"
+	fuzz "github.com/google/gofuzz"
+	jsoniter "github.com/json-iterator/go"
+)
+
+func Test_Roundtrip(t *testing.T) {
+	fz := fuzz.New().MaxDepth(10).NilChance(0.3)
+	for i := 0; i < 1000; i++ {
+		var before T
+		fz.Fuzz(&before)
+
+		jbStd, err := json.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with stdlib: %v", err)
+		}
+		jbIter, err := jsoniter.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with jsoniter: %v", err)
+		}
+		if string(jbStd) != string(jbIter) {
+			t.Errorf("marshal expected:\n    %s\ngot:\n    %s\nobj:\n    %s",
+				indent(jbStd, "    "), indent(jbIter, "    "), dump(before))
+		}
+
+		var afterStd T
+		err = json.Unmarshal(jbIter, &afterStd)
+		if err != nil {
+			t.Errorf("failed to unmarshal with stdlib: %v", err)
+		}
+		var afterIter T
+		err = jsoniter.Unmarshal(jbIter, &afterIter)
+		if err != nil {
+			t.Errorf("failed to unmarshal with jsoniter: %v", err)
+		}
+		if fingerprint(afterStd) != fingerprint(afterIter) {
+			t.Errorf("unmarshal expected:\n    %s\ngot:\n    %s\nvia:\n    %s",
+				dump(afterStd), dump(afterIter), indent(jbIter, "    "))
+		}
+	}
+}
+
+const indentStr = ">  "
+
+func fingerprint(obj interface{}) string {
+	c := spew.ConfigState{
+		SortKeys: true,
+		SpewKeys: true,
+	}
+	return c.Sprintf("%v", obj)
+}
+
+func dump(obj interface{}) string {
+	cfg := spew.ConfigState{
+		Indent: indentStr,
+	}
+	return cfg.Sdump(obj)
+}
+
+func indent(src []byte, prefix string) string {
+	var buf bytes.Buffer
+	json.Indent(&buf, src, prefix, indentStr)
+	return buf.String()
+}
+
+func BenchmarkStandardMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := json.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkStandardUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = json.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}
+
+func BenchmarkJSONIterMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := jsoniter.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkJSONIterUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = jsoniter.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}

--- a/output_tests/maps/pointers/uint16/ptr_string/types.go
+++ b/output_tests/maps/pointers/uint16/ptr_string/types.go
@@ -1,0 +1,3 @@
+package test
+
+type T map[uint16]*string

--- a/output_tests/maps/pointers/uint16/ptr_uint8/json_test.go
+++ b/output_tests/maps/pointers/uint16/ptr_uint8/json_test.go
@@ -1,0 +1,144 @@
+package test
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/davecgh/go-spew/spew"
+	fuzz "github.com/google/gofuzz"
+	jsoniter "github.com/json-iterator/go"
+)
+
+func Test_Roundtrip(t *testing.T) {
+	fz := fuzz.New().MaxDepth(10).NilChance(0.3)
+	for i := 0; i < 1000; i++ {
+		var before T
+		fz.Fuzz(&before)
+
+		jbStd, err := json.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with stdlib: %v", err)
+		}
+		jbIter, err := jsoniter.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with jsoniter: %v", err)
+		}
+		if string(jbStd) != string(jbIter) {
+			t.Errorf("marshal expected:\n    %s\ngot:\n    %s\nobj:\n    %s",
+				indent(jbStd, "    "), indent(jbIter, "    "), dump(before))
+		}
+
+		var afterStd T
+		err = json.Unmarshal(jbIter, &afterStd)
+		if err != nil {
+			t.Errorf("failed to unmarshal with stdlib: %v", err)
+		}
+		var afterIter T
+		err = jsoniter.Unmarshal(jbIter, &afterIter)
+		if err != nil {
+			t.Errorf("failed to unmarshal with jsoniter: %v", err)
+		}
+		if fingerprint(afterStd) != fingerprint(afterIter) {
+			t.Errorf("unmarshal expected:\n    %s\ngot:\n    %s\nvia:\n    %s",
+				dump(afterStd), dump(afterIter), indent(jbIter, "    "))
+		}
+	}
+}
+
+const indentStr = ">  "
+
+func fingerprint(obj interface{}) string {
+	c := spew.ConfigState{
+		SortKeys: true,
+		SpewKeys: true,
+	}
+	return c.Sprintf("%v", obj)
+}
+
+func dump(obj interface{}) string {
+	cfg := spew.ConfigState{
+		Indent: indentStr,
+	}
+	return cfg.Sdump(obj)
+}
+
+func indent(src []byte, prefix string) string {
+	var buf bytes.Buffer
+	json.Indent(&buf, src, prefix, indentStr)
+	return buf.String()
+}
+
+func BenchmarkStandardMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := json.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkStandardUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = json.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}
+
+func BenchmarkJSONIterMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := jsoniter.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkJSONIterUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = jsoniter.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}

--- a/output_tests/maps/pointers/uint16/ptr_uint8/types.go
+++ b/output_tests/maps/pointers/uint16/ptr_uint8/types.go
@@ -1,0 +1,3 @@
+package test
+
+type T map[uint16]*uint8


### PR DESCRIPTION
This is not ready for merge yet, but FYI.  I started working on this in another context, but it seems to apply equally well here.

This is a battery of tests that will test your JSON library against Go's standard encoding/json.

Caveats:
* This currently only covers builtins and maps.  I have more but ran out of time porting them tonight.
* The benchmark numbers are worth looking at, even in the builtins case - there are some cases where you do more allocs than std.
* This is waiting on a couple of gofuzz PRs to be merged. 
* This has already flagged several incompatibilities, so it will fail until those are resolved (a couple of issues were filed already).

Example:

```
thockin@thockin-glaptop2 go output_tests /output_tests$ go test -run=xxx -bench=. ./builtins/...
BenchmarkStandardMarshal-4     	 5000000	       565 ns/op	     185 B/op	       3 allocs/op
BenchmarkStandardUnmarshal-4   	 2000000	       632 ns/op	     289 B/op	       2 allocs/op
BenchmarkJSONIterMarshal-4     	 5000000	       406 ns/op	     353 B/op	       4 allocs/op
BenchmarkJSONIterUnmarshal-4   	10000000	       334 ns/op	      81 B/op	       2 allocs/op
PASS
ok  	_/home/thockin/src/go/src/github.com/json-iterator/go/output_tests/builtins/bool	11.164s
BenchmarkStandardMarshal-4     	 3000000	       541 ns/op	     185 B/op	       3 allocs/op
BenchmarkStandardUnmarshal-4   	 3000000	       614 ns/op	     289 B/op	       2 allocs/op
BenchmarkJSONIterMarshal-4     	 3000000	       403 ns/op	     353 B/op	       4 allocs/op
BenchmarkJSONIterUnmarshal-4   	10000000	       297 ns/op	      81 B/op	       2 allocs/op
PASS
ok  	_/home/thockin/src/go/src/github.com/json-iterator/go/output_tests/builtins/bool_alias	9.224s
BenchmarkStandardMarshal-4     	 2000000	       633 ns/op	     185 B/op	       3 allocs/op
BenchmarkStandardUnmarshal-4   	 2000000	       617 ns/op	     292 B/op	       3 allocs/op
BenchmarkJSONIterMarshal-4     	 5000000	       421 ns/op	     353 B/op	       4 allocs/op
BenchmarkJSONIterUnmarshal-4   	 5000000	       324 ns/op	      81 B/op	       2 allocs/op
PASS
ok  	_/home/thockin/src/go/src/github.com/json-iterator/go/output_tests/builtins/byte	8.357s
BenchmarkStandardMarshal-4     	 3000000	       678 ns/op	     185 B/op	       3 allocs/op
BenchmarkStandardUnmarshal-4   	 3000000	       618 ns/op	     292 B/op	       3 allocs/op
BenchmarkJSONIterMarshal-4     	 5000000	       367 ns/op	     353 B/op	       4 allocs/op
BenchmarkJSONIterUnmarshal-4   	10000000	       224 ns/op	      81 B/op	       2 allocs/op
PASS
```