### PR TITLE
Output tests

### DIFF
--- a/output_tests/slices/builtins/bool/json_test.go
+++ b/output_tests/slices/builtins/bool/json_test.go
@@ -1,0 +1,144 @@
+package test
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/davecgh/go-spew/spew"
+	fuzz "github.com/google/gofuzz"
+	jsoniter "github.com/json-iterator/go"
+)
+
+func Test_Roundtrip(t *testing.T) {
+	fz := fuzz.New().MaxDepth(10).NilChance(0.3)
+	for i := 0; i < 1000; i++ {
+		var before T
+		fz.Fuzz(&before)
+
+		jbStd, err := json.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with stdlib: %v", err)
+		}
+		jbIter, err := jsoniter.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with jsoniter: %v", err)
+		}
+		if string(jbStd) != string(jbIter) {
+			t.Errorf("marshal expected:\n    %s\ngot:\n    %s\nobj:\n    %s",
+				indent(jbStd, "    "), indent(jbIter, "    "), dump(before))
+		}
+
+		var afterStd T
+		err = json.Unmarshal(jbIter, &afterStd)
+		if err != nil {
+			t.Errorf("failed to unmarshal with stdlib: %v", err)
+		}
+		var afterIter T
+		err = jsoniter.Unmarshal(jbIter, &afterIter)
+		if err != nil {
+			t.Errorf("failed to unmarshal with jsoniter: %v", err)
+		}
+		if fingerprint(afterStd) != fingerprint(afterIter) {
+			t.Errorf("unmarshal expected:\n    %s\ngot:\n    %s\nvia:\n    %s",
+				dump(afterStd), dump(afterIter), indent(jbIter, "    "))
+		}
+	}
+}
+
+const indentStr = ">  "
+
+func fingerprint(obj interface{}) string {
+	c := spew.ConfigState{
+		SortKeys: true,
+		SpewKeys: true,
+	}
+	return c.Sprintf("%v", obj)
+}
+
+func dump(obj interface{}) string {
+	cfg := spew.ConfigState{
+		Indent: indentStr,
+	}
+	return cfg.Sdump(obj)
+}
+
+func indent(src []byte, prefix string) string {
+	var buf bytes.Buffer
+	json.Indent(&buf, src, prefix, indentStr)
+	return buf.String()
+}
+
+func BenchmarkStandardMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := json.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkStandardUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = json.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}
+
+func BenchmarkJSONIterMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := jsoniter.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkJSONIterUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = jsoniter.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}

--- a/output_tests/slices/builtins/bool/types.go
+++ b/output_tests/slices/builtins/bool/types.go
@@ -1,0 +1,3 @@
+package test
+
+type T []bool

--- a/output_tests/slices/builtins/byte/json_test.go
+++ b/output_tests/slices/builtins/byte/json_test.go
@@ -1,0 +1,144 @@
+package test
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/davecgh/go-spew/spew"
+	fuzz "github.com/google/gofuzz"
+	jsoniter "github.com/json-iterator/go"
+)
+
+func Test_Roundtrip(t *testing.T) {
+	fz := fuzz.New().MaxDepth(10).NilChance(0.3)
+	for i := 0; i < 1000; i++ {
+		var before T
+		fz.Fuzz(&before)
+
+		jbStd, err := json.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with stdlib: %v", err)
+		}
+		jbIter, err := jsoniter.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with jsoniter: %v", err)
+		}
+		if string(jbStd) != string(jbIter) {
+			t.Errorf("marshal expected:\n    %s\ngot:\n    %s\nobj:\n    %s",
+				indent(jbStd, "    "), indent(jbIter, "    "), dump(before))
+		}
+
+		var afterStd T
+		err = json.Unmarshal(jbIter, &afterStd)
+		if err != nil {
+			t.Errorf("failed to unmarshal with stdlib: %v", err)
+		}
+		var afterIter T
+		err = jsoniter.Unmarshal(jbIter, &afterIter)
+		if err != nil {
+			t.Errorf("failed to unmarshal with jsoniter: %v", err)
+		}
+		if fingerprint(afterStd) != fingerprint(afterIter) {
+			t.Errorf("unmarshal expected:\n    %s\ngot:\n    %s\nvia:\n    %s",
+				dump(afterStd), dump(afterIter), indent(jbIter, "    "))
+		}
+	}
+}
+
+const indentStr = ">  "
+
+func fingerprint(obj interface{}) string {
+	c := spew.ConfigState{
+		SortKeys: true,
+		SpewKeys: true,
+	}
+	return c.Sprintf("%v", obj)
+}
+
+func dump(obj interface{}) string {
+	cfg := spew.ConfigState{
+		Indent: indentStr,
+	}
+	return cfg.Sdump(obj)
+}
+
+func indent(src []byte, prefix string) string {
+	var buf bytes.Buffer
+	json.Indent(&buf, src, prefix, indentStr)
+	return buf.String()
+}
+
+func BenchmarkStandardMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := json.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkStandardUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = json.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}
+
+func BenchmarkJSONIterMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := jsoniter.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkJSONIterUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = jsoniter.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}

--- a/output_tests/slices/builtins/byte/types.go
+++ b/output_tests/slices/builtins/byte/types.go
@@ -1,0 +1,3 @@
+package test
+
+type T []byte

--- a/output_tests/slices/builtins/float32/json_test.go
+++ b/output_tests/slices/builtins/float32/json_test.go
@@ -1,0 +1,144 @@
+package test
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/davecgh/go-spew/spew"
+	fuzz "github.com/google/gofuzz"
+	jsoniter "github.com/json-iterator/go"
+)
+
+func Test_Roundtrip(t *testing.T) {
+	fz := fuzz.New().MaxDepth(10).NilChance(0.3)
+	for i := 0; i < 1000; i++ {
+		var before T
+		fz.Fuzz(&before)
+
+		jbStd, err := json.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with stdlib: %v", err)
+		}
+		jbIter, err := jsoniter.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with jsoniter: %v", err)
+		}
+		if string(jbStd) != string(jbIter) {
+			t.Errorf("marshal expected:\n    %s\ngot:\n    %s\nobj:\n    %s",
+				indent(jbStd, "    "), indent(jbIter, "    "), dump(before))
+		}
+
+		var afterStd T
+		err = json.Unmarshal(jbIter, &afterStd)
+		if err != nil {
+			t.Errorf("failed to unmarshal with stdlib: %v", err)
+		}
+		var afterIter T
+		err = jsoniter.Unmarshal(jbIter, &afterIter)
+		if err != nil {
+			t.Errorf("failed to unmarshal with jsoniter: %v", err)
+		}
+		if fingerprint(afterStd) != fingerprint(afterIter) {
+			t.Errorf("unmarshal expected:\n    %s\ngot:\n    %s\nvia:\n    %s",
+				dump(afterStd), dump(afterIter), indent(jbIter, "    "))
+		}
+	}
+}
+
+const indentStr = ">  "
+
+func fingerprint(obj interface{}) string {
+	c := spew.ConfigState{
+		SortKeys: true,
+		SpewKeys: true,
+	}
+	return c.Sprintf("%v", obj)
+}
+
+func dump(obj interface{}) string {
+	cfg := spew.ConfigState{
+		Indent: indentStr,
+	}
+	return cfg.Sdump(obj)
+}
+
+func indent(src []byte, prefix string) string {
+	var buf bytes.Buffer
+	json.Indent(&buf, src, prefix, indentStr)
+	return buf.String()
+}
+
+func BenchmarkStandardMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := json.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkStandardUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = json.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}
+
+func BenchmarkJSONIterMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := jsoniter.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkJSONIterUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = jsoniter.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}

--- a/output_tests/slices/builtins/float32/types.go
+++ b/output_tests/slices/builtins/float32/types.go
@@ -1,0 +1,3 @@
+package test
+
+type T []float32

--- a/output_tests/slices/builtins/float64/json_test.go
+++ b/output_tests/slices/builtins/float64/json_test.go
@@ -1,0 +1,144 @@
+package test
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/davecgh/go-spew/spew"
+	fuzz "github.com/google/gofuzz"
+	jsoniter "github.com/json-iterator/go"
+)
+
+func Test_Roundtrip(t *testing.T) {
+	fz := fuzz.New().MaxDepth(10).NilChance(0.3)
+	for i := 0; i < 1000; i++ {
+		var before T
+		fz.Fuzz(&before)
+
+		jbStd, err := json.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with stdlib: %v", err)
+		}
+		jbIter, err := jsoniter.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with jsoniter: %v", err)
+		}
+		if string(jbStd) != string(jbIter) {
+			t.Errorf("marshal expected:\n    %s\ngot:\n    %s\nobj:\n    %s",
+				indent(jbStd, "    "), indent(jbIter, "    "), dump(before))
+		}
+
+		var afterStd T
+		err = json.Unmarshal(jbIter, &afterStd)
+		if err != nil {
+			t.Errorf("failed to unmarshal with stdlib: %v", err)
+		}
+		var afterIter T
+		err = jsoniter.Unmarshal(jbIter, &afterIter)
+		if err != nil {
+			t.Errorf("failed to unmarshal with jsoniter: %v", err)
+		}
+		if fingerprint(afterStd) != fingerprint(afterIter) {
+			t.Errorf("unmarshal expected:\n    %s\ngot:\n    %s\nvia:\n    %s",
+				dump(afterStd), dump(afterIter), indent(jbIter, "    "))
+		}
+	}
+}
+
+const indentStr = ">  "
+
+func fingerprint(obj interface{}) string {
+	c := spew.ConfigState{
+		SortKeys: true,
+		SpewKeys: true,
+	}
+	return c.Sprintf("%v", obj)
+}
+
+func dump(obj interface{}) string {
+	cfg := spew.ConfigState{
+		Indent: indentStr,
+	}
+	return cfg.Sdump(obj)
+}
+
+func indent(src []byte, prefix string) string {
+	var buf bytes.Buffer
+	json.Indent(&buf, src, prefix, indentStr)
+	return buf.String()
+}
+
+func BenchmarkStandardMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := json.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkStandardUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = json.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}
+
+func BenchmarkJSONIterMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := jsoniter.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkJSONIterUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = jsoniter.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}

--- a/output_tests/slices/builtins/float64/types.go
+++ b/output_tests/slices/builtins/float64/types.go
@@ -1,0 +1,3 @@
+package test
+
+type T []float64

--- a/output_tests/slices/builtins/int32/json_test.go
+++ b/output_tests/slices/builtins/int32/json_test.go
@@ -1,0 +1,144 @@
+package test
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/davecgh/go-spew/spew"
+	fuzz "github.com/google/gofuzz"
+	jsoniter "github.com/json-iterator/go"
+)
+
+func Test_Roundtrip(t *testing.T) {
+	fz := fuzz.New().MaxDepth(10).NilChance(0.3)
+	for i := 0; i < 1000; i++ {
+		var before T
+		fz.Fuzz(&before)
+
+		jbStd, err := json.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with stdlib: %v", err)
+		}
+		jbIter, err := jsoniter.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with jsoniter: %v", err)
+		}
+		if string(jbStd) != string(jbIter) {
+			t.Errorf("marshal expected:\n    %s\ngot:\n    %s\nobj:\n    %s",
+				indent(jbStd, "    "), indent(jbIter, "    "), dump(before))
+		}
+
+		var afterStd T
+		err = json.Unmarshal(jbIter, &afterStd)
+		if err != nil {
+			t.Errorf("failed to unmarshal with stdlib: %v", err)
+		}
+		var afterIter T
+		err = jsoniter.Unmarshal(jbIter, &afterIter)
+		if err != nil {
+			t.Errorf("failed to unmarshal with jsoniter: %v", err)
+		}
+		if fingerprint(afterStd) != fingerprint(afterIter) {
+			t.Errorf("unmarshal expected:\n    %s\ngot:\n    %s\nvia:\n    %s",
+				dump(afterStd), dump(afterIter), indent(jbIter, "    "))
+		}
+	}
+}
+
+const indentStr = ">  "
+
+func fingerprint(obj interface{}) string {
+	c := spew.ConfigState{
+		SortKeys: true,
+		SpewKeys: true,
+	}
+	return c.Sprintf("%v", obj)
+}
+
+func dump(obj interface{}) string {
+	cfg := spew.ConfigState{
+		Indent: indentStr,
+	}
+	return cfg.Sdump(obj)
+}
+
+func indent(src []byte, prefix string) string {
+	var buf bytes.Buffer
+	json.Indent(&buf, src, prefix, indentStr)
+	return buf.String()
+}
+
+func BenchmarkStandardMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := json.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkStandardUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = json.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}
+
+func BenchmarkJSONIterMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := jsoniter.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkJSONIterUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = jsoniter.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}

--- a/output_tests/slices/builtins/int32/types.go
+++ b/output_tests/slices/builtins/int32/types.go
@@ -1,0 +1,3 @@
+package test
+
+type T []int32

--- a/output_tests/slices/builtins/int8/json_test.go
+++ b/output_tests/slices/builtins/int8/json_test.go
@@ -1,0 +1,144 @@
+package test
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/davecgh/go-spew/spew"
+	fuzz "github.com/google/gofuzz"
+	jsoniter "github.com/json-iterator/go"
+)
+
+func Test_Roundtrip(t *testing.T) {
+	fz := fuzz.New().MaxDepth(10).NilChance(0.3)
+	for i := 0; i < 1000; i++ {
+		var before T
+		fz.Fuzz(&before)
+
+		jbStd, err := json.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with stdlib: %v", err)
+		}
+		jbIter, err := jsoniter.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with jsoniter: %v", err)
+		}
+		if string(jbStd) != string(jbIter) {
+			t.Errorf("marshal expected:\n    %s\ngot:\n    %s\nobj:\n    %s",
+				indent(jbStd, "    "), indent(jbIter, "    "), dump(before))
+		}
+
+		var afterStd T
+		err = json.Unmarshal(jbIter, &afterStd)
+		if err != nil {
+			t.Errorf("failed to unmarshal with stdlib: %v", err)
+		}
+		var afterIter T
+		err = jsoniter.Unmarshal(jbIter, &afterIter)
+		if err != nil {
+			t.Errorf("failed to unmarshal with jsoniter: %v", err)
+		}
+		if fingerprint(afterStd) != fingerprint(afterIter) {
+			t.Errorf("unmarshal expected:\n    %s\ngot:\n    %s\nvia:\n    %s",
+				dump(afterStd), dump(afterIter), indent(jbIter, "    "))
+		}
+	}
+}
+
+const indentStr = ">  "
+
+func fingerprint(obj interface{}) string {
+	c := spew.ConfigState{
+		SortKeys: true,
+		SpewKeys: true,
+	}
+	return c.Sprintf("%v", obj)
+}
+
+func dump(obj interface{}) string {
+	cfg := spew.ConfigState{
+		Indent: indentStr,
+	}
+	return cfg.Sdump(obj)
+}
+
+func indent(src []byte, prefix string) string {
+	var buf bytes.Buffer
+	json.Indent(&buf, src, prefix, indentStr)
+	return buf.String()
+}
+
+func BenchmarkStandardMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := json.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkStandardUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = json.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}
+
+func BenchmarkJSONIterMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := jsoniter.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkJSONIterUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = jsoniter.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}

--- a/output_tests/slices/builtins/int8/types.go
+++ b/output_tests/slices/builtins/int8/types.go
@@ -1,0 +1,3 @@
+package test
+
+type T []int8

--- a/output_tests/slices/builtins/string/json_test.go
+++ b/output_tests/slices/builtins/string/json_test.go
@@ -1,0 +1,144 @@
+package test
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/davecgh/go-spew/spew"
+	fuzz "github.com/google/gofuzz"
+	jsoniter "github.com/json-iterator/go"
+)
+
+func Test_Roundtrip(t *testing.T) {
+	fz := fuzz.New().MaxDepth(10).NilChance(0.3)
+	for i := 0; i < 1000; i++ {
+		var before T
+		fz.Fuzz(&before)
+
+		jbStd, err := json.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with stdlib: %v", err)
+		}
+		jbIter, err := jsoniter.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with jsoniter: %v", err)
+		}
+		if string(jbStd) != string(jbIter) {
+			t.Errorf("marshal expected:\n    %s\ngot:\n    %s\nobj:\n    %s",
+				indent(jbStd, "    "), indent(jbIter, "    "), dump(before))
+		}
+
+		var afterStd T
+		err = json.Unmarshal(jbIter, &afterStd)
+		if err != nil {
+			t.Errorf("failed to unmarshal with stdlib: %v", err)
+		}
+		var afterIter T
+		err = jsoniter.Unmarshal(jbIter, &afterIter)
+		if err != nil {
+			t.Errorf("failed to unmarshal with jsoniter: %v", err)
+		}
+		if fingerprint(afterStd) != fingerprint(afterIter) {
+			t.Errorf("unmarshal expected:\n    %s\ngot:\n    %s\nvia:\n    %s",
+				dump(afterStd), dump(afterIter), indent(jbIter, "    "))
+		}
+	}
+}
+
+const indentStr = ">  "
+
+func fingerprint(obj interface{}) string {
+	c := spew.ConfigState{
+		SortKeys: true,
+		SpewKeys: true,
+	}
+	return c.Sprintf("%v", obj)
+}
+
+func dump(obj interface{}) string {
+	cfg := spew.ConfigState{
+		Indent: indentStr,
+	}
+	return cfg.Sdump(obj)
+}
+
+func indent(src []byte, prefix string) string {
+	var buf bytes.Buffer
+	json.Indent(&buf, src, prefix, indentStr)
+	return buf.String()
+}
+
+func BenchmarkStandardMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := json.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkStandardUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = json.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}
+
+func BenchmarkJSONIterMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := jsoniter.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkJSONIterUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = jsoniter.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}

--- a/output_tests/slices/builtins/string/types.go
+++ b/output_tests/slices/builtins/string/types.go
@@ -1,0 +1,3 @@
+package test
+
+type T []string

--- a/output_tests/slices/builtins/uint8/json_test.go
+++ b/output_tests/slices/builtins/uint8/json_test.go
@@ -1,0 +1,144 @@
+package test
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/davecgh/go-spew/spew"
+	fuzz "github.com/google/gofuzz"
+	jsoniter "github.com/json-iterator/go"
+)
+
+func Test_Roundtrip(t *testing.T) {
+	fz := fuzz.New().MaxDepth(10).NilChance(0.3)
+	for i := 0; i < 1000; i++ {
+		var before T
+		fz.Fuzz(&before)
+
+		jbStd, err := json.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with stdlib: %v", err)
+		}
+		jbIter, err := jsoniter.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with jsoniter: %v", err)
+		}
+		if string(jbStd) != string(jbIter) {
+			t.Errorf("marshal expected:\n    %s\ngot:\n    %s\nobj:\n    %s",
+				indent(jbStd, "    "), indent(jbIter, "    "), dump(before))
+		}
+
+		var afterStd T
+		err = json.Unmarshal(jbIter, &afterStd)
+		if err != nil {
+			t.Errorf("failed to unmarshal with stdlib: %v", err)
+		}
+		var afterIter T
+		err = jsoniter.Unmarshal(jbIter, &afterIter)
+		if err != nil {
+			t.Errorf("failed to unmarshal with jsoniter: %v", err)
+		}
+		if fingerprint(afterStd) != fingerprint(afterIter) {
+			t.Errorf("unmarshal expected:\n    %s\ngot:\n    %s\nvia:\n    %s",
+				dump(afterStd), dump(afterIter), indent(jbIter, "    "))
+		}
+	}
+}
+
+const indentStr = ">  "
+
+func fingerprint(obj interface{}) string {
+	c := spew.ConfigState{
+		SortKeys: true,
+		SpewKeys: true,
+	}
+	return c.Sprintf("%v", obj)
+}
+
+func dump(obj interface{}) string {
+	cfg := spew.ConfigState{
+		Indent: indentStr,
+	}
+	return cfg.Sdump(obj)
+}
+
+func indent(src []byte, prefix string) string {
+	var buf bytes.Buffer
+	json.Indent(&buf, src, prefix, indentStr)
+	return buf.String()
+}
+
+func BenchmarkStandardMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := json.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkStandardUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = json.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}
+
+func BenchmarkJSONIterMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := jsoniter.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkJSONIterUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = jsoniter.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}

--- a/output_tests/slices/builtins/uint8/types.go
+++ b/output_tests/slices/builtins/uint8/types.go
@@ -1,0 +1,3 @@
+package test
+
+type T []uint8

--- a/output_tests/slices/pointers/bool/json_test.go
+++ b/output_tests/slices/pointers/bool/json_test.go
@@ -1,0 +1,144 @@
+package test
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/davecgh/go-spew/spew"
+	fuzz "github.com/google/gofuzz"
+	jsoniter "github.com/json-iterator/go"
+)
+
+func Test_Roundtrip(t *testing.T) {
+	fz := fuzz.New().MaxDepth(10).NilChance(0.3)
+	for i := 0; i < 1000; i++ {
+		var before T
+		fz.Fuzz(&before)
+
+		jbStd, err := json.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with stdlib: %v", err)
+		}
+		jbIter, err := jsoniter.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with jsoniter: %v", err)
+		}
+		if string(jbStd) != string(jbIter) {
+			t.Errorf("marshal expected:\n    %s\ngot:\n    %s\nobj:\n    %s",
+				indent(jbStd, "    "), indent(jbIter, "    "), dump(before))
+		}
+
+		var afterStd T
+		err = json.Unmarshal(jbIter, &afterStd)
+		if err != nil {
+			t.Errorf("failed to unmarshal with stdlib: %v", err)
+		}
+		var afterIter T
+		err = jsoniter.Unmarshal(jbIter, &afterIter)
+		if err != nil {
+			t.Errorf("failed to unmarshal with jsoniter: %v", err)
+		}
+		if fingerprint(afterStd) != fingerprint(afterIter) {
+			t.Errorf("unmarshal expected:\n    %s\ngot:\n    %s\nvia:\n    %s",
+				dump(afterStd), dump(afterIter), indent(jbIter, "    "))
+		}
+	}
+}
+
+const indentStr = ">  "
+
+func fingerprint(obj interface{}) string {
+	c := spew.ConfigState{
+		SortKeys: true,
+		SpewKeys: true,
+	}
+	return c.Sprintf("%v", obj)
+}
+
+func dump(obj interface{}) string {
+	cfg := spew.ConfigState{
+		Indent: indentStr,
+	}
+	return cfg.Sdump(obj)
+}
+
+func indent(src []byte, prefix string) string {
+	var buf bytes.Buffer
+	json.Indent(&buf, src, prefix, indentStr)
+	return buf.String()
+}
+
+func BenchmarkStandardMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := json.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkStandardUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = json.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}
+
+func BenchmarkJSONIterMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := jsoniter.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkJSONIterUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = jsoniter.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}

--- a/output_tests/slices/pointers/bool/types.go
+++ b/output_tests/slices/pointers/bool/types.go
@@ -1,0 +1,3 @@
+package test
+
+type T []*bool

--- a/output_tests/slices/pointers/float32/json_test.go
+++ b/output_tests/slices/pointers/float32/json_test.go
@@ -1,0 +1,144 @@
+package test
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/davecgh/go-spew/spew"
+	fuzz "github.com/google/gofuzz"
+	jsoniter "github.com/json-iterator/go"
+)
+
+func Test_Roundtrip(t *testing.T) {
+	fz := fuzz.New().MaxDepth(10).NilChance(0.3)
+	for i := 0; i < 1000; i++ {
+		var before T
+		fz.Fuzz(&before)
+
+		jbStd, err := json.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with stdlib: %v", err)
+		}
+		jbIter, err := jsoniter.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with jsoniter: %v", err)
+		}
+		if string(jbStd) != string(jbIter) {
+			t.Errorf("marshal expected:\n    %s\ngot:\n    %s\nobj:\n    %s",
+				indent(jbStd, "    "), indent(jbIter, "    "), dump(before))
+		}
+
+		var afterStd T
+		err = json.Unmarshal(jbIter, &afterStd)
+		if err != nil {
+			t.Errorf("failed to unmarshal with stdlib: %v", err)
+		}
+		var afterIter T
+		err = jsoniter.Unmarshal(jbIter, &afterIter)
+		if err != nil {
+			t.Errorf("failed to unmarshal with jsoniter: %v", err)
+		}
+		if fingerprint(afterStd) != fingerprint(afterIter) {
+			t.Errorf("unmarshal expected:\n    %s\ngot:\n    %s\nvia:\n    %s",
+				dump(afterStd), dump(afterIter), indent(jbIter, "    "))
+		}
+	}
+}
+
+const indentStr = ">  "
+
+func fingerprint(obj interface{}) string {
+	c := spew.ConfigState{
+		SortKeys: true,
+		SpewKeys: true,
+	}
+	return c.Sprintf("%v", obj)
+}
+
+func dump(obj interface{}) string {
+	cfg := spew.ConfigState{
+		Indent: indentStr,
+	}
+	return cfg.Sdump(obj)
+}
+
+func indent(src []byte, prefix string) string {
+	var buf bytes.Buffer
+	json.Indent(&buf, src, prefix, indentStr)
+	return buf.String()
+}
+
+func BenchmarkStandardMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := json.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkStandardUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = json.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}
+
+func BenchmarkJSONIterMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := jsoniter.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkJSONIterUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = jsoniter.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}

--- a/output_tests/slices/pointers/float32/types.go
+++ b/output_tests/slices/pointers/float32/types.go
@@ -1,0 +1,3 @@
+package test
+
+type T []*float32

--- a/output_tests/slices/pointers/float64/json_test.go
+++ b/output_tests/slices/pointers/float64/json_test.go
@@ -1,0 +1,144 @@
+package test
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/davecgh/go-spew/spew"
+	fuzz "github.com/google/gofuzz"
+	jsoniter "github.com/json-iterator/go"
+)
+
+func Test_Roundtrip(t *testing.T) {
+	fz := fuzz.New().MaxDepth(10).NilChance(0.3)
+	for i := 0; i < 1000; i++ {
+		var before T
+		fz.Fuzz(&before)
+
+		jbStd, err := json.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with stdlib: %v", err)
+		}
+		jbIter, err := jsoniter.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with jsoniter: %v", err)
+		}
+		if string(jbStd) != string(jbIter) {
+			t.Errorf("marshal expected:\n    %s\ngot:\n    %s\nobj:\n    %s",
+				indent(jbStd, "    "), indent(jbIter, "    "), dump(before))
+		}
+
+		var afterStd T
+		err = json.Unmarshal(jbIter, &afterStd)
+		if err != nil {
+			t.Errorf("failed to unmarshal with stdlib: %v", err)
+		}
+		var afterIter T
+		err = jsoniter.Unmarshal(jbIter, &afterIter)
+		if err != nil {
+			t.Errorf("failed to unmarshal with jsoniter: %v", err)
+		}
+		if fingerprint(afterStd) != fingerprint(afterIter) {
+			t.Errorf("unmarshal expected:\n    %s\ngot:\n    %s\nvia:\n    %s",
+				dump(afterStd), dump(afterIter), indent(jbIter, "    "))
+		}
+	}
+}
+
+const indentStr = ">  "
+
+func fingerprint(obj interface{}) string {
+	c := spew.ConfigState{
+		SortKeys: true,
+		SpewKeys: true,
+	}
+	return c.Sprintf("%v", obj)
+}
+
+func dump(obj interface{}) string {
+	cfg := spew.ConfigState{
+		Indent: indentStr,
+	}
+	return cfg.Sdump(obj)
+}
+
+func indent(src []byte, prefix string) string {
+	var buf bytes.Buffer
+	json.Indent(&buf, src, prefix, indentStr)
+	return buf.String()
+}
+
+func BenchmarkStandardMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := json.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkStandardUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = json.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}
+
+func BenchmarkJSONIterMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := jsoniter.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkJSONIterUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = jsoniter.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}

--- a/output_tests/slices/pointers/float64/types.go
+++ b/output_tests/slices/pointers/float64/types.go
@@ -1,0 +1,3 @@
+package test
+
+type T []*float64

--- a/output_tests/slices/pointers/int32/json_test.go
+++ b/output_tests/slices/pointers/int32/json_test.go
@@ -1,0 +1,144 @@
+package test
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/davecgh/go-spew/spew"
+	fuzz "github.com/google/gofuzz"
+	jsoniter "github.com/json-iterator/go"
+)
+
+func Test_Roundtrip(t *testing.T) {
+	fz := fuzz.New().MaxDepth(10).NilChance(0.3)
+	for i := 0; i < 1000; i++ {
+		var before T
+		fz.Fuzz(&before)
+
+		jbStd, err := json.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with stdlib: %v", err)
+		}
+		jbIter, err := jsoniter.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with jsoniter: %v", err)
+		}
+		if string(jbStd) != string(jbIter) {
+			t.Errorf("marshal expected:\n    %s\ngot:\n    %s\nobj:\n    %s",
+				indent(jbStd, "    "), indent(jbIter, "    "), dump(before))
+		}
+
+		var afterStd T
+		err = json.Unmarshal(jbIter, &afterStd)
+		if err != nil {
+			t.Errorf("failed to unmarshal with stdlib: %v", err)
+		}
+		var afterIter T
+		err = jsoniter.Unmarshal(jbIter, &afterIter)
+		if err != nil {
+			t.Errorf("failed to unmarshal with jsoniter: %v", err)
+		}
+		if fingerprint(afterStd) != fingerprint(afterIter) {
+			t.Errorf("unmarshal expected:\n    %s\ngot:\n    %s\nvia:\n    %s",
+				dump(afterStd), dump(afterIter), indent(jbIter, "    "))
+		}
+	}
+}
+
+const indentStr = ">  "
+
+func fingerprint(obj interface{}) string {
+	c := spew.ConfigState{
+		SortKeys: true,
+		SpewKeys: true,
+	}
+	return c.Sprintf("%v", obj)
+}
+
+func dump(obj interface{}) string {
+	cfg := spew.ConfigState{
+		Indent: indentStr,
+	}
+	return cfg.Sdump(obj)
+}
+
+func indent(src []byte, prefix string) string {
+	var buf bytes.Buffer
+	json.Indent(&buf, src, prefix, indentStr)
+	return buf.String()
+}
+
+func BenchmarkStandardMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := json.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkStandardUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = json.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}
+
+func BenchmarkJSONIterMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := jsoniter.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkJSONIterUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = jsoniter.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}

--- a/output_tests/slices/pointers/int32/types.go
+++ b/output_tests/slices/pointers/int32/types.go
@@ -1,0 +1,3 @@
+package test
+
+type T []*int32

--- a/output_tests/slices/pointers/int8/json_test.go
+++ b/output_tests/slices/pointers/int8/json_test.go
@@ -1,0 +1,144 @@
+package test
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/davecgh/go-spew/spew"
+	fuzz "github.com/google/gofuzz"
+	jsoniter "github.com/json-iterator/go"
+)
+
+func Test_Roundtrip(t *testing.T) {
+	fz := fuzz.New().MaxDepth(10).NilChance(0.3)
+	for i := 0; i < 1000; i++ {
+		var before T
+		fz.Fuzz(&before)
+
+		jbStd, err := json.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with stdlib: %v", err)
+		}
+		jbIter, err := jsoniter.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with jsoniter: %v", err)
+		}
+		if string(jbStd) != string(jbIter) {
+			t.Errorf("marshal expected:\n    %s\ngot:\n    %s\nobj:\n    %s",
+				indent(jbStd, "    "), indent(jbIter, "    "), dump(before))
+		}
+
+		var afterStd T
+		err = json.Unmarshal(jbIter, &afterStd)
+		if err != nil {
+			t.Errorf("failed to unmarshal with stdlib: %v", err)
+		}
+		var afterIter T
+		err = jsoniter.Unmarshal(jbIter, &afterIter)
+		if err != nil {
+			t.Errorf("failed to unmarshal with jsoniter: %v", err)
+		}
+		if fingerprint(afterStd) != fingerprint(afterIter) {
+			t.Errorf("unmarshal expected:\n    %s\ngot:\n    %s\nvia:\n    %s",
+				dump(afterStd), dump(afterIter), indent(jbIter, "    "))
+		}
+	}
+}
+
+const indentStr = ">  "
+
+func fingerprint(obj interface{}) string {
+	c := spew.ConfigState{
+		SortKeys: true,
+		SpewKeys: true,
+	}
+	return c.Sprintf("%v", obj)
+}
+
+func dump(obj interface{}) string {
+	cfg := spew.ConfigState{
+		Indent: indentStr,
+	}
+	return cfg.Sdump(obj)
+}
+
+func indent(src []byte, prefix string) string {
+	var buf bytes.Buffer
+	json.Indent(&buf, src, prefix, indentStr)
+	return buf.String()
+}
+
+func BenchmarkStandardMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := json.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkStandardUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = json.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}
+
+func BenchmarkJSONIterMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := jsoniter.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkJSONIterUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = jsoniter.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}

--- a/output_tests/slices/pointers/int8/types.go
+++ b/output_tests/slices/pointers/int8/types.go
@@ -1,0 +1,3 @@
+package test
+
+type T []*int8

--- a/output_tests/slices/pointers/string/json_test.go
+++ b/output_tests/slices/pointers/string/json_test.go
@@ -1,0 +1,144 @@
+package test
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/davecgh/go-spew/spew"
+	fuzz "github.com/google/gofuzz"
+	jsoniter "github.com/json-iterator/go"
+)
+
+func Test_Roundtrip(t *testing.T) {
+	fz := fuzz.New().MaxDepth(10).NilChance(0.3)
+	for i := 0; i < 1000; i++ {
+		var before T
+		fz.Fuzz(&before)
+
+		jbStd, err := json.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with stdlib: %v", err)
+		}
+		jbIter, err := jsoniter.Marshal(before)
+		if err != nil {
+			t.Errorf("failed to marshal with jsoniter: %v", err)
+		}
+		if string(jbStd) != string(jbIter) {
+			t.Errorf("marshal expected:\n    %s\ngot:\n    %s\nobj:\n    %s",
+				indent(jbStd, "    "), indent(jbIter, "    "), dump(before))
+		}
+
+		var afterStd T
+		err = json.Unmarshal(jbIter, &afterStd)
+		if err != nil {
+			t.Errorf("failed to unmarshal with stdlib: %v", err)
+		}
+		var afterIter T
+		err = jsoniter.Unmarshal(jbIter, &afterIter)
+		if err != nil {
+			t.Errorf("failed to unmarshal with jsoniter: %v", err)
+		}
+		if fingerprint(afterStd) != fingerprint(afterIter) {
+			t.Errorf("unmarshal expected:\n    %s\ngot:\n    %s\nvia:\n    %s",
+				dump(afterStd), dump(afterIter), indent(jbIter, "    "))
+		}
+	}
+}
+
+const indentStr = ">  "
+
+func fingerprint(obj interface{}) string {
+	c := spew.ConfigState{
+		SortKeys: true,
+		SpewKeys: true,
+	}
+	return c.Sprintf("%v", obj)
+}
+
+func dump(obj interface{}) string {
+	cfg := spew.ConfigState{
+		Indent: indentStr,
+	}
+	return cfg.Sdump(obj)
+}
+
+func indent(src []byte, prefix string) string {
+	var buf bytes.Buffer
+	json.Indent(&buf, src, prefix, indentStr)
+	return buf.String()
+}
+
+func BenchmarkStandardMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := json.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkStandardUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = json.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}
+
+func BenchmarkJSONIterMarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var obj T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&obj)
+	for i := 0; i < t.N; i++ {
+		jb, err := jsoniter.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal:\n input: %s\n  error: %v", dump(obj), err)
+		}
+		_ = jb
+	}
+}
+
+func BenchmarkJSONIterUnmarshal(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	var before T
+	fz := fuzz.NewWithSeed(0).MaxDepth(10).NilChance(0.3)
+	fz.Fuzz(&before)
+	jb, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	for i := 0; i < t.N; i++ {
+		var after T
+		err = jsoniter.Unmarshal(jb, &after)
+		if err != nil {
+			t.Fatalf("failed to unmarshal:\n  input: %q\n  error: %v", string(jb), err)
+		}
+	}
+}

--- a/output_tests/slices/pointers/string/types.go
+++ b/output_tests/slices/pointers/string/types.go
@@ -1,0 +1,3 @@
+package test
+
+type T []*string


### PR DESCRIPTION
Add output tests for slices of builtins and pointers.

Adapt tests to use new Config structs
    
The unit test uses compatible mode.  The benchmarks measure compat, default, and fastest.
    
This still fails for strings and slices and maps all over the place.

As before, json_test.go is EXACTLY the same in every directory.
