### PR TITLE
fix(reflect): don't process ignored struct fields

### DIFF
--- a/feature_reflect_extension.go
+++ b/feature_reflect_extension.go
@@ -200,7 +200,12 @@ func describeStruct(cfg *frozenConfig, typ reflect.Type) (*StructDescriptor, err
 	bindings := []*Binding{}
 	for i := 0; i < typ.NumField(); i++ {
 		field := typ.Field(i)
-		if field.Anonymous && (field.Tag.Get("json") == "" || strings.Split(field.Tag.Get("json"), ",")[0] == "") {
+		tag := field.Tag.Get("json")
+		tagParts := strings.Split(tag, ",")
+		if tag == "-" {
+			continue
+		}
+		if field.Anonymous && (tag == "" || tagParts[0] == "") {
 			if field.Type.Kind() == reflect.Struct {
 				structDescriptor, err := describeStruct(cfg, field.Type)
 				if err != nil {
@@ -231,8 +236,7 @@ func describeStruct(cfg *frozenConfig, typ reflect.Type) (*StructDescriptor, err
 				continue
 			}
 		}
-		tagParts := strings.Split(field.Tag.Get("json"), ",")
-		fieldNames := calcFieldNames(field.Name, tagParts[0], string(field.Tag.Get("json")))
+		fieldNames := calcFieldNames(field.Name, tagParts[0], tag)
 		fieldCacheKey := fmt.Sprintf("%s/%s", typ.String(), field.Name)
 		decoder := fieldDecoders[fieldCacheKey]
 		if decoder == nil {

--- a/jsoniter_object_test.go
+++ b/jsoniter_object_test.go
@@ -404,6 +404,20 @@ func Test_omit_empty(t *testing.T) {
 	should.Equal(`{"field-2":"hello"}`, str)
 }
 
+func Test_ignore_field_on_not_valid_type(t *testing.T) {
+	should := require.New(t)
+	type TestObject struct {
+		Field1 string `json:"field-1,omitempty"`
+		Field2 func() `json:"-"`
+	}
+	obj := TestObject{}
+	obj.Field1 = "hello world"
+	obj.Field2 = func() {}
+	str, err := MarshalToString(&obj)
+	should.Nil(err)
+	should.Equal(`{"field-1":"hello world"}`, str)
+}
+
 func Test_recursive_struct(t *testing.T) {
 	should := require.New(t)
 	type TestObject struct {


### PR DESCRIPTION
Following [json-iterator/go#120](https://github.com/json-iterator/go/issues/120) , https://github.com/gin-gonic/gin/issues/991