### PR TITLE
fix(sortKeysMapEncoder): add space between map key and value

### DIFF
--- a/feature_reflect_map.go
+++ b/feature_reflect_map.go
@@ -186,6 +186,9 @@ func (encoder *sortKeysMapEncoder) Encode(ptr unsafe.Pointer, stream *Stream) {
 		}
 		stream.WriteVal(key.s) // might need html escape, so can not WriteString directly
 		stream.writeByte(':')
+		if stream.indention > 0 {
+			stream.writeByte(' ')
+		}
 		val := realVal.MapIndex(key.v).Interface()
 		encoder.elemEncoder.EncodeInterface(val, stream)
 	}


### PR DESCRIPTION
See https://github.com/json-iterator/go/issues/126#issuecomment-314168745.  Please review and advice.