### PR TITLE
support decoding booleans in a string context

### DIFF
--- a/feature_iter_string.go
+++ b/feature_iter_string.go
@@ -27,8 +27,14 @@ func (iter *Iterator) ReadString() (ret string) {
 	} else if c == 'n' {
 		iter.skipThreeBytes('u', 'l', 'l')
 		return ""
+	} else if c == 't' {
+		iter.skipThreeBytes('r', 'u', 'e')
+		return "true"
+	} else if c == 'f' {
+		iter.skipFourBytes('a', 'l', 's', 'e')
+		return "false"
 	}
-	iter.ReportError("ReadString", `expects " or n`)
+	iter.ReportError("ReadString", `expects ", n, f, or t`)
 	return
 }
 


### PR DESCRIPTION
Addresses cases such as the following:

v := struct{
    Selector map[string]string `json:"selector"`
}{}
dataToDecode := `{
    "selector": {
        "field": false
    }
}`
dataToDecodeAsYAML := `
selector:
  field: no
`
where the output struct expects a map of string keys and values, and the input contains non-quoted boolean values.

Particularly in cases where the input is yaml and is later converted into json before being decoded, this patch prevents a potentially confusing error where a user might use a yaml-specific boolean keyword (such as yes or no), and then is presented with a decoder error similar to [pos 36]: json: expect char '"' but got char 'f'

Related downstream bug: https://bugzilla.redhat.com/show_bug.cgi?id=1458204#c1

cc @fabianofranz