### PR TITLE
Shorter sleep while waiting for encoder/decoder

### DIFF
--- a/feature_reflect.go
+++ b/feature_reflect.go
@@ -154,11 +154,11 @@ func (encoder *placeholderEncoder) IsEmpty(ptr unsafe.Pointer) bool {
 }
 
 func (encoder *placeholderEncoder) getRealEncoder() ValEncoder {
-	for i := 0; i < 30; i++ {
+	for i := 0; i < 500; i++ {
 		realDecoder := encoder.cfg.getEncoderFromCache(encoder.cacheKey)
 		_, isPlaceholder := realDecoder.(*placeholderEncoder)
 		if isPlaceholder {
-			time.Sleep(time.Second)
+			time.Sleep(10 * time.Millisecond)
 		} else {
 			return realDecoder
 		}
@@ -172,11 +172,11 @@ type placeholderDecoder struct {
 }
 
 func (decoder *placeholderDecoder) Decode(ptr unsafe.Pointer, iter *Iterator) {
-	for i := 0; i < 30; i++ {
+	for i := 0; i < 500; i++ {
 		realDecoder := decoder.cfg.getDecoderFromCache(decoder.cacheKey)
 		_, isPlaceholder := realDecoder.(*placeholderDecoder)
 		if isPlaceholder {
-			time.Sleep(time.Second)
+			time.Sleep(10 * time.Millisecond)
 		} else {
 			realDecoder.Decode(ptr, iter)
 			return


### PR DESCRIPTION
If the client is using the same jsoniter config with multiple goroutines
it's very likely that few initial operations will encounter a placeholder
encoder/decoder while the real one is being created by another
goroutine. Having a full second sleep seems too conservative, since
encoder/decoder will be created in a very short time. This is very easy
to reproduce in any real environment with a few concurrent requests of
the same type. A few initial requests will have 1s+ response time.

Changing to 10ms should smooth out marshal/unmarshal times for these
initial concurrent requests.