### PR TITLE
Fix handling of nil empty interface

### DIFF
--- a/feature_reflect_native.go
+++ b/feature_reflect_native.go
@@ -373,7 +373,8 @@ func (codec *emptyInterfaceCodec) EncodeInterface(val interface{}, stream *Strea
 }
 
 func (codec *emptyInterfaceCodec) IsEmpty(ptr unsafe.Pointer) bool {
-	return ptr == nil
+	emptyInterface := (*emptyInterface)(ptr)
+	return emptyInterface.typ == nil
 }
 
 type nonEmptyInterfaceCodec struct {

--- a/jsoniter_interface_test.go
+++ b/jsoniter_interface_test.go
@@ -351,3 +351,22 @@ func Test_nil_out_null_interface(t *testing.T) {
 	should.Equal(nil, err)
 	should.Equal(nil, obj2.Field)
 }
+
+func Test_omitempty_nil_interface(t *testing.T) {
+	type TestData struct {
+		Field interface{} `json:"field,omitempty"`
+	}
+	should := require.New(t)
+
+	obj := TestData{
+		Field: nil,
+	}
+
+	js, err := json.Marshal(obj)
+	should.Equal(nil, err)
+	should.Equal("{}", string(js))
+
+	str, err := MarshalToString(obj)
+	should.Equal(nil, err)
+	should.Equal(string(js), str)
+}


### PR DESCRIPTION
Before:

```
go test .
--- FAIL: Test_omitempty_nil_interface (0.00s)
        Error Trace:    jsoniter_interface_test.go:371
	Error:      	Not equal: 
	            	expected: "{}"
	            	actual: "{\"field\":null}"
FAIL
FAIL	github.com/json-iterator/go	0.148s
```

Relevant code in reflect package: https://golang.org/src/reflect/value.go#L132

