### PR TITLE
Fix custom marshaler for enum types

### DIFF
--- a/feature_reflect.go
+++ b/feature_reflect.go
@@ -476,7 +476,6 @@ func createEncoderOfType(cfg *frozenConfig, typ reflect.Type) (ValEncoder, error
 			templateInterface: extractInterface(templateInterface),
 			checkIsEmpty:      checkIsEmpty,
 		}
-		encoder = &optionalEncoder{encoder}
 		return encoder, nil
 	}
 	if typ.Implements(textMarshalerType) {

--- a/feature_reflect_native.go
+++ b/feature_reflect_native.go
@@ -661,6 +661,7 @@ func (encoder *marshalerEncoder) Encode(ptr unsafe.Pointer, stream *Stream) {
 	templateInterface.word = ptr
 	realInterface := (*interface{})(unsafe.Pointer(&templateInterface))
 	marshaler := (*realInterface).(json.Marshaler)
+
 	bytes, err := marshaler.MarshalJSON()
 	if err != nil {
 		stream.Error = err

--- a/jsoniter_enum_marshaler_test.go
+++ b/jsoniter_enum_marshaler_test.go
@@ -1,0 +1,50 @@
+package jsoniter
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type MyEnum int64
+
+const (
+	MyEnumA MyEnum = iota
+	MyEnumB
+)
+
+func (m *MyEnum) MarshalJSON() ([]byte, error) {
+	return []byte(fmt.Sprintf(`"foo-%d"`, int(*m))), nil
+}
+
+func (m *MyEnum) UnmarshalJSON(jb []byte) error {
+	switch string(jb) {
+	case `"foo-1"`:
+		*m = MyEnumB
+	default:
+		*m = MyEnumA
+	}
+	return nil
+}
+
+func Test_custom_marshaler_on_enum(t *testing.T) {
+	type Wrapper struct {
+		Payload interface{}
+	}
+	type Wrapper2 struct {
+		Payload MyEnum
+	}
+	should := require.New(t)
+
+	w := Wrapper{Payload: MyEnumB}
+
+	jb, err := Marshal(w)
+	should.Equal(nil, err)
+	should.Equal(`{"Payload":"foo-1"}`, string(jb))
+
+	var w2 Wrapper2
+	err = Unmarshal(jb, &w2)
+	should.Equal(nil, err)
+	should.Equal(MyEnumB, w2.Payload)
+}


### PR DESCRIPTION
When MarshalJSON was defined on a pointer receiver custom enum type
marshaling/unmarshaling was panicing since the underlying primitive type
was treated as a pointer.

Since method set for pointer receivers includes value receiver methods
we don't really need optionalEncoder and can just use marshalEncoder
directly.

```
--- FAIL: Test_custom_marshaler_on_enum (0.00s)
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x1 pc=0x133d7a6]

goroutine 6 [running]:
testing.tRunner.func1(0xc42007b1e0)
	/usr/local/go/src/testing/testing.go:622 +0x29d
panic(0x13eb880, 0x1647d90)
	/usr/local/go/src/runtime/panic.go:489 +0x2cf
github.com/olegshaldybin/go.(*MyEnum).MarshalJSON(0x1, 0x13ec960, 0x1, 0x179b0e0, 0x1, 0xc4200c39e0)
	/Users/oleg/go/src/github.com/olegshaldybin/go/jsoniter_enum_marshaler_test.go:18 +0x26
github.com/olegshaldybin/go.(*marshalerEncoder).Encode(0xc4200f1300, 0x1, 0xc420018b40)
	/Users/oleg/go/src/github.com/olegshaldybin/go/feature_reflect_native.go:665 +0x6b
github.com/olegshaldybin/go.(*optionalEncoder).Encode(0xc42010e6a0, 0xc42010e5d0, 0xc420018b40)
	/Users/oleg/go/src/github.com/olegshaldybin/go/feature_reflect.go:124 +0x4f
github.com/olegshaldybin/go.WriteToStream(0x13c81e0, 0xc42010e5d0, 0xc420018b40, 0x1622ce0, 0xc42010e6a0)
	/Users/oleg/go/src/github.com/olegshaldybin/go/feature_reflect.go:49 +0x10b
github.com/olegshaldybin/go.(*optionalEncoder).EncodeInterface(0xc42010e6a0, 0x13c81e0, 0xc42010e5d0, 0xc420018b40)
	/Users/oleg/go/src/github.com/olegshaldybin/go/feature_reflect.go:129 +0x55
github.com/olegshaldybin/go.(*Stream).WriteVal(0xc420018b40, 0x13c81e0, 0xc42010e5d0)
	/Users/oleg/go/src/github.com/olegshaldybin/go/feature_reflect.go:234 +0xe4
github.com/olegshaldybin/go.(*emptyInterfaceCodec).Encode(0x1670410, 0xc42010e5e0, 0xc420018b40)
	/Users/oleg/go/src/github.com/olegshaldybin/go/feature_reflect_native.go:368 +0x41
github.com/olegshaldybin/go.(*structFieldEncoder).Encode(0xc4200f1240, 0xc42010e5e0, 0xc420018b40)
	/Users/oleg/go/src/github.com/olegshaldybin/go/feature_reflect_object.go:118 +0x5c
github.com/olegshaldybin/go.(*structEncoder).Encode(0xc4200f12c0, 0xc42010e5e0, 0xc420018b40)
	/Users/oleg/go/src/github.com/olegshaldybin/go/feature_reflect_object.go:155 +0xc2
github.com/olegshaldybin/go.(*structEncoder).EncodeInterface(0xc4200f12c0, 0x13f8e80, 0xc42010e5e0, 0xc420018b40)
	/Users/oleg/go/src/github.com/olegshaldybin/go/feature_reflect_object.go:175 +0x145
github.com/olegshaldybin/go.(*Stream).WriteVal(0xc420018b40, 0x13f8e80, 0xc42010e5e0)
	/Users/oleg/go/src/github.com/olegshaldybin/go/feature_reflect.go:234 +0xe4
github.com/olegshaldybin/go.(*frozenConfig).Marshal(0xc4200bcc40, 0x13f8e80, 0xc42010e5e0, 0x0, 0x0, 0x0, 0x0, 0x0)
	/Users/oleg/go/src/github.com/olegshaldybin/go/feature_config.go:257 +0xdb
github.com/olegshaldybin/go.Marshal(0x13f8e80, 0xc42010e5e0, 0x13f8e80, 0xc42010e5e0, 0x1, 0x3, 0xc420102340)
	/Users/oleg/go/src/github.com/olegshaldybin/go/feature_adapter.go:43 +0x49
github.com/olegshaldybin/go.Test_custom_marshaler_on_enum(0xc42007b1e0)
	/Users/oleg/go/src/github.com/olegshaldybin/go/jsoniter_enum_marshaler_test.go:42 +0xd8
testing.tRunner(0xc42007b1e0, 0x1471208)
	/usr/local/go/src/testing/testing.go:657 +0x96
created by testing.(*T).Run
	/usr/local/go/src/testing/testing.go:697 +0x2ca
exit status 2
```