### PR TITLE
More nil interface fixes

### DIFF
--- a/feature_reflect_native.go
+++ b/feature_reflect_native.go
@@ -391,6 +391,9 @@ func (codec *nonEmptyInterfaceCodec) Decode(ptr unsafe.Pointer, iter *Iterator) 
 	e.typ = nonEmptyInterface.itab.typ
 	e.word = nonEmptyInterface.word
 	iter.ReadVal(&i)
+	if e.word == nil {
+		nonEmptyInterface.itab = nil
+	}
 	nonEmptyInterface.word = e.word
 }
 

--- a/feature_reflect_native.go
+++ b/feature_reflect_native.go
@@ -662,7 +662,11 @@ func (encoder *marshalerEncoder) Encode(ptr unsafe.Pointer, stream *Stream) {
 	templateInterface := encoder.templateInterface
 	templateInterface.word = ptr
 	realInterface := (*interface{})(unsafe.Pointer(&templateInterface))
-	marshaler := (*realInterface).(json.Marshaler)
+	marshaler, ok := (*realInterface).(json.Marshaler)
+	if !ok {
+		stream.WriteVal(nil)
+		return
+	}
 
 	bytes, err := marshaler.MarshalJSON()
 	if err != nil {

--- a/feature_reflect_native.go
+++ b/feature_reflect_native.go
@@ -397,9 +397,11 @@ func (codec *nonEmptyInterfaceCodec) Decode(ptr unsafe.Pointer, iter *Iterator) 
 func (codec *nonEmptyInterfaceCodec) Encode(ptr unsafe.Pointer, stream *Stream) {
 	nonEmptyInterface := (*nonEmptyInterface)(ptr)
 	var i interface{}
-	e := (*emptyInterface)(unsafe.Pointer(&i))
-	e.typ = nonEmptyInterface.itab.typ
-	e.word = nonEmptyInterface.word
+	if nonEmptyInterface.itab != nil {
+		e := (*emptyInterface)(unsafe.Pointer(&i))
+		e.typ = nonEmptyInterface.itab.typ
+		e.word = nonEmptyInterface.word
+	}
 	stream.WriteVal(i)
 }
 

--- a/jsoniter_bool_test.go
+++ b/jsoniter_bool_test.go
@@ -92,22 +92,22 @@ func Test_bool_can_be_null(t *testing.T) {
 	obj := TestData{}
 	data1 := []byte(`{"field": true}`)
 	err := Unmarshal(data1, &obj)
-	should.Equal(nil, err)
+	should.NoError(err)
 	should.Equal(true, obj.Field)
 
 	data2 := []byte(`{"field": null}`)
 	err = Unmarshal(data2, &obj)
-	should.Equal(nil, err)
+	should.NoError(err)
 	// Same behavior as stdlib, not touching the existing value.
 	should.Equal(true, obj.Field)
 
 	// Checking stdlib behavior as well
 	obj2 := TestData{}
 	err = json.Unmarshal(data1, &obj2)
-	should.Equal(nil, err)
+	should.NoError(err)
 	should.Equal(true, obj2.Field)
 
 	err = json.Unmarshal(data2, &obj2)
-	should.Equal(nil, err)
+	should.NoError(err)
 	should.Equal(true, obj2.Field)
 }

--- a/jsoniter_enum_marshaler_test.go
+++ b/jsoniter_enum_marshaler_test.go
@@ -40,11 +40,11 @@ func Test_custom_marshaler_on_enum(t *testing.T) {
 	w := Wrapper{Payload: MyEnumB}
 
 	jb, err := Marshal(w)
-	should.Equal(nil, err)
+	should.NoError(err)
 	should.Equal(`{"Payload":"foo-1"}`, string(jb))
 
 	var w2 Wrapper2
 	err = Unmarshal(jb, &w2)
-	should.Equal(nil, err)
+	should.NoError(err)
 	should.Equal(MyEnumB, w2.Payload)
 }

--- a/jsoniter_interface_test.go
+++ b/jsoniter_interface_test.go
@@ -389,7 +389,8 @@ func Test_omitempty_nil_nonempty_interface(t *testing.T) {
 	should.Equal(nil, err)
 	should.Equal(string(js), str)
 
-	err = Unmarshal(js, &obj)
+	obj.Field = MyString("hello")
+	err = UnmarshalFromString(`{"field":null}`, &obj)
 	should.Equal(nil, err)
 	should.Equal(nil, obj.Field)
 }

--- a/jsoniter_interface_test.go
+++ b/jsoniter_interface_test.go
@@ -371,6 +371,29 @@ func Test_omitempty_nil_interface(t *testing.T) {
 	should.Equal(string(js), str)
 }
 
+func Test_omitempty_nil_nonempty_interface(t *testing.T) {
+	type TestData struct {
+		Field MyInterface `json:"field,omitempty"`
+	}
+	should := require.New(t)
+
+	obj := TestData{
+		Field: nil,
+	}
+
+	js, err := json.Marshal(obj)
+	should.Equal(nil, err)
+	should.Equal("{}", string(js))
+
+	str, err := MarshalToString(obj)
+	should.Equal(nil, err)
+	should.Equal(string(js), str)
+
+	err = Unmarshal(js, &obj)
+	should.Equal(nil, err)
+	should.Equal(nil, obj.Field)
+}
+
 func Test_marshal_nil_marshaler_interface(t *testing.T) {
 	type TestData struct {
 		Field json.Marshaler `json:"field"`
@@ -407,4 +430,9 @@ func Test_marshal_nil_nonempty_interface(t *testing.T) {
 	str, err := MarshalToString(obj)
 	should.Equal(nil, err)
 	should.Equal(string(js), str)
+
+	obj.Field = MyString("hello")
+	err = Unmarshal(js, &obj)
+	should.Equal(nil, err)
+	should.Equal(nil, obj.Field)
 }

--- a/jsoniter_interface_test.go
+++ b/jsoniter_interface_test.go
@@ -370,3 +370,41 @@ func Test_omitempty_nil_interface(t *testing.T) {
 	should.Equal(nil, err)
 	should.Equal(string(js), str)
 }
+
+func Test_marshal_nil_marshaler_interface(t *testing.T) {
+	type TestData struct {
+		Field json.Marshaler `json:"field"`
+	}
+	should := require.New(t)
+
+	obj := TestData{
+		Field: nil,
+	}
+
+	js, err := json.Marshal(obj)
+	should.Equal(nil, err)
+	should.Equal(`{"field":null}`, string(js))
+
+	str, err := MarshalToString(obj)
+	should.Equal(nil, err)
+	should.Equal(string(js), str)
+}
+
+func Test_marshal_nil_nonempty_interface(t *testing.T) {
+	type TestData struct {
+		Field MyInterface `json:"field"`
+	}
+	should := require.New(t)
+
+	obj := TestData{
+		Field: nil,
+	}
+
+	js, err := json.Marshal(obj)
+	should.Equal(nil, err)
+	should.Equal(`{"field":null}`, string(js))
+
+	str, err := MarshalToString(obj)
+	should.Equal(nil, err)
+	should.Equal(string(js), str)
+}

--- a/jsoniter_interface_test.go
+++ b/jsoniter_interface_test.go
@@ -329,13 +329,13 @@ func Test_nil_out_null_interface(t *testing.T) {
 	data1 := []byte(`{"field": true}`)
 
 	err := Unmarshal(data1, &obj)
-	should.Equal(nil, err)
+	should.NoError(err)
 	should.Equal(true, *(obj.Field.(*bool)))
 
 	data2 := []byte(`{"field": null}`)
 
 	err = Unmarshal(data2, &obj)
-	should.Equal(nil, err)
+	should.NoError(err)
 	should.Equal(nil, obj.Field)
 
 	// Checking stdlib behavior matches.
@@ -344,11 +344,11 @@ func Test_nil_out_null_interface(t *testing.T) {
 	}
 
 	err = json.Unmarshal(data1, &obj2)
-	should.Equal(nil, err)
+	should.NoError(err)
 	should.Equal(true, *(obj2.Field.(*bool)))
 
 	err = json.Unmarshal(data2, &obj2)
-	should.Equal(nil, err)
+	should.NoError(err)
 	should.Equal(nil, obj2.Field)
 }
 
@@ -363,11 +363,11 @@ func Test_omitempty_nil_interface(t *testing.T) {
 	}
 
 	js, err := json.Marshal(obj)
-	should.Equal(nil, err)
+	should.NoError(err)
 	should.Equal("{}", string(js))
 
 	str, err := MarshalToString(obj)
-	should.Equal(nil, err)
+	should.NoError(err)
 	should.Equal(string(js), str)
 }
 
@@ -382,16 +382,16 @@ func Test_omitempty_nil_nonempty_interface(t *testing.T) {
 	}
 
 	js, err := json.Marshal(obj)
-	should.Equal(nil, err)
+	should.NoError(err)
 	should.Equal("{}", string(js))
 
 	str, err := MarshalToString(obj)
-	should.Equal(nil, err)
+	should.NoError(err)
 	should.Equal(string(js), str)
 
 	obj.Field = MyString("hello")
 	err = UnmarshalFromString(`{"field":null}`, &obj)
-	should.Equal(nil, err)
+	should.NoError(err)
 	should.Equal(nil, obj.Field)
 }
 
@@ -406,11 +406,11 @@ func Test_marshal_nil_marshaler_interface(t *testing.T) {
 	}
 
 	js, err := json.Marshal(obj)
-	should.Equal(nil, err)
+	should.NoError(err)
 	should.Equal(`{"field":null}`, string(js))
 
 	str, err := MarshalToString(obj)
-	should.Equal(nil, err)
+	should.NoError(err)
 	should.Equal(string(js), str)
 }
 
@@ -425,15 +425,15 @@ func Test_marshal_nil_nonempty_interface(t *testing.T) {
 	}
 
 	js, err := json.Marshal(obj)
-	should.Equal(nil, err)
+	should.NoError(err)
 	should.Equal(`{"field":null}`, string(js))
 
 	str, err := MarshalToString(obj)
-	should.Equal(nil, err)
+	should.NoError(err)
 	should.Equal(string(js), str)
 
 	obj.Field = MyString("hello")
 	err = Unmarshal(js, &obj)
-	should.Equal(nil, err)
+	should.NoError(err)
 	should.Equal(nil, obj.Field)
 }


### PR DESCRIPTION
This fixes a few more issues with encoding and decoding nil interfaces.

1. encoding nil non-empty interfaces was failing
2. encoding of nil `json.Marshaler` interfaces was failing
3. decoding of interfaces where the JSON value was nil was failing

Unrelated: replaced usage of `should.Equal(nil, err)` with `should.NoError(err)` in tests.