### PR TITLE
Fix encoding 0-length arrays

### DIFF
--- a/feature_reflect_array.go
+++ b/feature_reflect_array.go
@@ -13,11 +13,28 @@ func decoderOfArray(cfg *frozenConfig, prefix string, typ reflect.Type) ValDecod
 }
 
 func encoderOfArray(cfg *frozenConfig, prefix string, typ reflect.Type) ValEncoder {
+	if typ.Len() == 0 {
+		return emptyArrayEncoder{}
+	}
 	encoder := encoderOfType(cfg, prefix+"[array]->", typ.Elem())
 	if typ.Elem().Kind() == reflect.Map {
 		encoder = &OptionalEncoder{encoder}
 	}
 	return &arrayEncoder{typ, typ.Elem(), encoder}
+}
+
+type emptyArrayEncoder struct{}
+
+func (encoder emptyArrayEncoder) Encode(ptr unsafe.Pointer, stream *Stream) {
+	stream.WriteEmptyArray()
+}
+
+func (encoder emptyArrayEncoder) EncodeInterface(val interface{}, stream *Stream) {
+	stream.WriteEmptyArray()
+}
+
+func (encoder emptyArrayEncoder) IsEmpty(ptr unsafe.Pointer) bool {
+	return true
 }
 
 type arrayEncoder struct {
@@ -27,10 +44,6 @@ type arrayEncoder struct {
 }
 
 func (encoder *arrayEncoder) Encode(ptr unsafe.Pointer, stream *Stream) {
-	if encoder.arrayType.Len() == 0 {
-		stream.WriteEmptyArray()
-		return
-	}
 	stream.WriteArrayStart()
 	elemPtr := unsafe.Pointer(ptr)
 	encoder.elemEncoder.Encode(elemPtr, stream)

--- a/feature_reflect_array.go
+++ b/feature_reflect_array.go
@@ -27,6 +27,10 @@ type arrayEncoder struct {
 }
 
 func (encoder *arrayEncoder) Encode(ptr unsafe.Pointer, stream *Stream) {
+	if encoder.arrayType.Len() == 0 {
+		stream.WriteEmptyArray()
+		return
+	}
 	stream.WriteArrayStart()
 	elemPtr := unsafe.Pointer(ptr)
 	encoder.elemEncoder.Encode(elemPtr, stream)

--- a/jsoniter_fixed_array_test.go
+++ b/jsoniter_fixed_array_test.go
@@ -15,6 +15,15 @@ func Test_encode_fixed_array(t *testing.T) {
 	should.Equal("[0.1,1]", output)
 }
 
+func Test_encode_fixed_array_empty(t *testing.T) {
+	should := require.New(t)
+	type FixedArray [0]float64
+	fixed := FixedArray{}
+	output, err := MarshalToString(fixed)
+	should.Nil(err)
+	should.Equal("[]", output)
+}
+
 func Test_encode_fixed_array_of_map(t *testing.T) {
 	should := require.New(t)
 	type FixedArray [2]map[string]string


### PR DESCRIPTION
The array encoder assumed that arrays had at least one value, so it
would serialize them with a zero-value for the array, such as `[0]`.

This adds a test to reproduce the issue, and updates the encoder to
write an empty array if the length is 0.