### PR TITLE
Add a specific decoder for map[string][string]

### DIFF
--- a/map_string_string.go
+++ b/map_string_string.go
@@ -1,0 +1,47 @@
+package jsoniter
+
+import (
+	"unsafe"
+)
+
+type mapStringStringDecoder struct {
+}
+
+func (decoder *mapStringStringDecoder) Decode(ptr unsafe.Pointer, iter *Iterator) {
+	mapPtr := (*map[string]string)(ptr)
+	c := iter.nextToken()
+	if c == 'n' {
+		iter.skipThreeBytes('u', 'l', 'l')
+		*mapPtr = nil
+		return
+	}
+	if *mapPtr == nil {
+		*mapPtr = make(map[string]string)
+	}
+	if c != '{' {
+		iter.ReportError("ReadMapCB", `expect { or n, but found `+string([]byte{c}))
+		return
+	}
+	c = iter.nextToken()
+	if c == '}' {
+		return
+	}
+	if c != '"' {
+		iter.ReportError("ReadMapCB", `expect " after }, but found `+string([]byte{c}))
+		return
+	}
+	iter.unreadByte()
+	for c = ','; c == ','; c = iter.nextToken() {
+		key := iter.ReadString()
+		c = iter.nextToken()
+		if c != ':' {
+			iter.ReportError("ReadMapCB", "expect : after object field, but found "+string([]byte{c}))
+			return
+		}
+		elem := iter.ReadString()
+		(*mapPtr)[key] = elem
+	}
+	if c != '}' {
+		iter.ReportError("ReadMapCB", `expect }, but found `+string([]byte{c}))
+	}
+}

--- a/reflect_map.go
+++ b/reflect_map.go
@@ -11,6 +11,9 @@ import (
 
 func decoderOfMap(ctx *ctx, typ reflect2.Type) ValDecoder {
 	mapType := typ.(*reflect2.UnsafeMapType)
+	if mapType.Key().Kind() == reflect.String && mapType.Elem().Kind() == reflect.String {
+		return &mapStringStringDecoder{}
+	}
 	keyDecoder := decoderOfMapKey(ctx.append("[mapKey]"), mapType.Key())
 	elemDecoder := decoderOfType(ctx.append("[mapElem]"), mapType.Elem())
 	return &mapDecoder{


### PR DESCRIPTION
Just an idea I had to save memory allocations via `reflect`, for this common case.

I looked for a way to specify a decoder like this outside the library, but it seems that `Iterator` doesn't expose enough.  Also I would guess `map[string]string` is a pretty common target, so worth adding to the library.

The code itself is patterned after `mapDecoder.Decode()`.