### PR TITLE
Add a test for input errors, and fix one bug that it finds

### DIFF
--- a/reflect_struct_decoder.go
+++ b/reflect_struct_decoder.go
@@ -494,12 +494,15 @@ func (decoder *generalStructDecoder) Decode(ptr unsafe.Pointer, iter *Iterator) 
 	if !iter.readObjectStart() {
 		return
 	}
-	decoder.decodeOneField(ptr, iter)
-	for iter.nextToken() == ',' {
+	var c byte
+	for c = ','; c == ','; c = iter.nextToken() {
 		decoder.decodeOneField(ptr, iter)
 	}
 	if iter.Error != nil && iter.Error != io.EOF {
 		iter.Error = fmt.Errorf("%v.%s", decoder.typ, iter.Error.Error())
+	}
+	if c != '}' {
+		iter.ReportError("struct Decode", `expect }, but found `+string([]byte{c}))
 	}
 }
 

--- a/value_tests/error_test.go
+++ b/value_tests/error_test.go
@@ -1,0 +1,36 @@
+package test
+
+import (
+	"github.com/json-iterator/go"
+	"github.com/stretchr/testify/require"
+	"reflect"
+	"testing"
+)
+
+func Test_errorInput(t *testing.T) {
+	for _, testCase := range unmarshalCases {
+		if testCase.obj != nil {
+			continue
+		}
+		valType := reflect.TypeOf(testCase.ptr).Elem()
+		t.Run(valType.String(), func(t *testing.T) {
+			for _, data := range []string{
+				`x`,
+				`n`,
+				`nul`,
+				`{x}`,
+				`{"x"}`,
+				`{"x": "y"x}`,
+				`{"x": "y"`,
+				`{"x": "y", "a"}`,
+				`[`,
+				`[{"x": "y"}`,
+			} {
+				ptrVal := reflect.New(valType)
+				ptr := ptrVal.Interface()
+				err := jsoniter.ConfigCompatibleWithStandardLibrary.Unmarshal([]byte(data), ptr)
+				require.Error(t, err, "on input %q", data)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Since the bot complained that #254 reduced coverage, I thought I would add some coverage of error conditions.

And I found that `generalStructDecoder` did not check for closing `}`.
