### PR TITLE
Release writer to enable GC

### DIFF
--- a/pool.go
+++ b/pool.go
@@ -23,6 +23,7 @@ func (cfg *frozenConfig) BorrowStream(writer io.Writer) *Stream {
 }
 
 func (cfg *frozenConfig) ReturnStream(stream *Stream) {
+	stream.out = nil
 	stream.Error = nil
 	stream.Attachment = nil
 	cfg.streamPool.Put(stream)


### PR DESCRIPTION
There is no need to keep reference to the writer - it is going to be overwritten on `BorrowStream()` anyway. This PR clears the reference to enable GC to collect the writer if it is no longer needed.