### PR TITLE
fix base64 contains newline case

### DIFF
--- a/misc_tests/jsoniter_array_test.go
+++ b/misc_tests/jsoniter_array_test.go
@@ -3,9 +3,10 @@ package misc_tests
 import (
 	"bytes"
 	"encoding/json"
+	"testing"
+
 	"github.com/json-iterator/go"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 func Test_empty_array(t *testing.T) {
@@ -164,6 +165,17 @@ func Test_decode_byte_array_from_base64(t *testing.T) {
 	should.Nil(err)
 	should.Equal([]byte{1, 2, 3}, data)
 	err = jsoniter.Unmarshal([]byte(`"AQID"`), &data)
+	should.Nil(err)
+	should.Equal([]byte{1, 2, 3}, data)
+}
+
+func Test_decode_byte_array_from_base64_with_newlines(t *testing.T) {
+	should := require.New(t)
+	data := []byte{}
+	err := json.Unmarshal([]byte(`"A\rQ\nID"`), &data)
+	should.Nil(err)
+	should.Equal([]byte{1, 2, 3}, data)
+	err = jsoniter.Unmarshal([]byte(`"A\rQ\nID"`), &data)
 	should.Nil(err)
 	should.Equal([]byte{1, 2, 3}, data)
 }

--- a/reflect_native.go
+++ b/reflect_native.go
@@ -1,11 +1,13 @@
 package jsoniter
 
 import (
+	"bytes"
 	"encoding/base64"
-	"github.com/modern-go/reflect2"
 	"reflect"
 	"strconv"
 	"unsafe"
+
+	"github.com/modern-go/reflect2"
 )
 
 const ptrSize = 32 << uintptr(^uintptr(0)>>63)
@@ -418,6 +420,10 @@ func (codec *base64Codec) Decode(ptr unsafe.Pointer, iter *Iterator) {
 	case StringValue:
 		encoding := base64.StdEncoding
 		src := iter.SkipAndReturnBytes()
+		// New line characters (\r and \n) are ignored.
+		// Refer to https://golang.org/pkg/encoding/base64/#Encoding.Decode
+		src = bytes.Replace(src, []byte(`\r`), []byte{}, -1)
+		src = bytes.Replace(src, []byte(`\n`), []byte{}, -1)
 		src = src[1 : len(src)-1]
 		decodedLen := encoding.DecodedLen(len(src))
 		dst := make([]byte, decodedLen)


### PR DESCRIPTION
base64 decode fails if there is \n in byte slice

As mentioned in https://golang.org/pkg/encoding/base64/#Encoding.Decode

> New line characters (\r and \n) are ignored.

Therefore, I remove \r and \n before doing decode.