### PR TITLE
Support tabs on MarshalIndent (WIP)

### DIFF
--- a/config.go
+++ b/config.go
@@ -14,6 +14,7 @@ import (
 // The API is created from Config by Froze.
 type Config struct {
 	IndentionStep                 int
+	UseTabs                       bool
 	MarshalFloatWith6Digits       bool
 	EscapeHTML                    bool
 	SortMapKeys                   bool
@@ -67,6 +68,7 @@ type frozenConfig struct {
 	configBeforeFrozen            Config
 	sortMapKeys                   bool
 	indentionStep                 int
+	useTabs                       bool
 	objectFieldMustBeSimpleString bool
 	onlyTaggedField               bool
 	disallowUnknownFields         bool
@@ -125,6 +127,7 @@ func (cfg Config) Froze() API {
 	api := &frozenConfig{
 		sortMapKeys:                   cfg.SortMapKeys,
 		indentionStep:                 cfg.IndentionStep,
+		useTabs:                       cfg.UseTabs,
 		objectFieldMustBeSimpleString: cfg.ObjectFieldMustBeSimpleString,
 		onlyTaggedField:               cfg.OnlyTaggedField,
 		disallowUnknownFields:         cfg.DisallowUnknownFields,
@@ -300,16 +303,21 @@ func (cfg *frozenConfig) Marshal(v interface{}) ([]byte, error) {
 }
 
 func (cfg *frozenConfig) MarshalIndent(v interface{}, prefix, indent string) ([]byte, error) {
+	var useTabs bool
 	if prefix != "" {
 		panic("prefix is not supported")
 	}
 	for _, r := range indent {
-		if r != ' ' {
+		if r != ' ' && r != '\t' {
 			panic("indent can only be space")
+		}
+		if r == '\t' {
+			useTabs = true
 		}
 	}
 	newCfg := cfg.configBeforeFrozen
 	newCfg.IndentionStep = len(indent)
+	newCfg.UseTabs = useTabs
 	return newCfg.frozeWithCacheReuse().Marshal(v)
 }
 

--- a/stream.go
+++ b/stream.go
@@ -206,6 +206,10 @@ func (stream *Stream) writeIndention(delta int) {
 	stream.writeByte('\n')
 	toWrite := stream.indention - delta
 	for i := 0; i < toWrite; i++ {
-		stream.buf = append(stream.buf, ' ')
+		if !stream.cfg.useTabs {
+			stream.buf = append(stream.buf, ' ')
+		} else {
+			stream.buf = append(stream.buf, '\t')
+		}
 	}
 }


### PR DESCRIPTION
Fixes #253 

Support for using tabs on calls to `MarshalIndent` like so: 
```
json.MarshalIndent(v, "", "\t")
```
Todo:

- [ ] error check that mixed tabs and spaces are not supported
- [ ] tests
