### PR TITLE
BUGFIX: allow json tag overrides with set naming strategy

### DIFF
--- a/extra/naming_strategy.go
+++ b/extra/naming_strategy.go
@@ -17,8 +17,10 @@ type namingStrategyExtension struct {
 
 func (extension *namingStrategyExtension) UpdateStructDescriptor(structDescriptor *jsoniter.StructDescriptor) {
 	for _, binding := range structDescriptor.Fields {
-		binding.ToNames = []string{extension.translate(binding.Field.Name())}
-		binding.FromNames = []string{extension.translate(binding.Field.Name())}
+		if !binding.IgnoreOverride {
+			binding.ToNames = []string{extension.translate(binding.Field.Name())}
+			binding.FromNames = []string{extension.translate(binding.Field.Name())}
+		}
 	}
 }
 

--- a/reflect_extension.go
+++ b/reflect_extension.go
@@ -35,12 +35,12 @@ func (structDescriptor *StructDescriptor) GetField(fieldName string) *Binding {
 
 // Binding describe how should we encode/decode the struct field
 type Binding struct {
-	levels    []int
-	Field     reflect2.StructField
-	FromNames []string
-	ToNames   []string
-	Encoder   ValEncoder
-	Decoder   ValDecoder
+	levels         []int
+	Field          reflect2.StructField
+	FromNames      []string
+	ToNames        []string
+	Encoder        ValEncoder
+	Decoder        ValDecoder
 	IgnoreOverride bool
 }
 
@@ -375,11 +375,11 @@ func describeStruct(ctx *ctx, typ reflect2.Type) *StructDescriptor {
 			encoder = encoderOfType(ctx.append(field.Name()), field.Type())
 		}
 		binding := &Binding{
-			Field:     field,
-			FromNames: fieldNames,
-			ToNames:   fieldNames,
-			Decoder:   decoder,
-			Encoder:   encoder,
+			Field:          field,
+			FromNames:      fieldNames,
+			ToNames:        fieldNames,
+			Decoder:        decoder,
+			Encoder:        encoder,
 			IgnoreOverride: ignoreNameOverrides,
 		}
 		binding.levels = []int{i}


### PR DESCRIPTION
This allows users to use a set naming strategy, like so...

`extra.SetNamingStrategy(extra.LowerCaseWithUnderscores)`

...but also alias a field via the json tag to rename it:

```
type Response struct {
	Var1		string `json:"var"`
	FooBar	string
}
```

The above will result in the following JSON structure: `{"var":"some string value", "foo_bar":"some other string value"}`.

Prior to this change, one could not alias a struct field via the `json` tag to rename and have a set naming strategy.