### PR TITLE
ignore escaped double quote when ReadStringAsSlice

### DIFF
--- a/iter_str.go
+++ b/iter_str.go
@@ -119,7 +119,7 @@ func (iter *Iterator) ReadStringAsSlice() (ret []byte) {
 		for i := iter.head; i < iter.tail; i++ {
 			// require ascii string and no escape
 			// for: field name, base64, number
-			if iter.buf[i] == '"' {
+			if iter.buf[i] == '"' && iter.buf[i-1] != '\\' {
 				// fast path: reuse the underlying buffer
 				ret = iter.buf[iter.head:i]
 				iter.head = i + 1


### PR DESCRIPTION
Thanks taowen, I create a new binary as string codec for my product, like [this](https://gist.github.com/faceair/7826d6927467e58d669ebe4c6f23bb04).
I want add this patch to ignore the escaped double quote when ReadStringAsSlice, if not it's hard to read `"i say:\"hi\""`.