### PR TITLE
fix inconsistent calchash for utf8 tag

### DIFF
--- a/iter_object.go
+++ b/iter_object.go
@@ -2,7 +2,7 @@ package jsoniter
 
 import (
 	"fmt"
-	"unicode"
+	"strings"
 )
 
 // ReadObject read one field from object.
@@ -97,12 +97,11 @@ func (iter *Iterator) readFieldHash() int64 {
 
 func calcHash(str string, caseSensitive bool) int64 {
 	hash := int64(0x811c9dc5)
-	for _, b := range str {
-		if caseSensitive {
-			hash ^= int64(b)
-		} else {
-			hash ^= int64(unicode.ToLower(b))
-		}
+	if !caseSensitive {
+		str = strings.ToLower(str)
+	}
+	for _, b := range []byte(str) {
+		hash ^= int64(b)
 		hash *= 0x1000193
 	}
 	return int64(hash)

--- a/misc_tests/jsoniter_utf8_tag_test.go
+++ b/misc_tests/jsoniter_utf8_tag_test.go
@@ -1,0 +1,22 @@
+package misc_tests
+
+import (
+	"testing"
+
+	jsoniter "github.com/json-iterator/go"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUTF8StructTag(t *testing.T) {
+	jsonBlob := []byte(`{"姓名":"燕子"}`)
+
+	type User struct {
+		Name string `json:"姓名"`
+	}
+
+	should := require.New(t)
+	user := User{}
+	err := jsoniter.Unmarshal(jsonBlob, &user)
+	should.NoError(err)
+	should.Equal("燕子", user.Name)
+}


### PR DESCRIPTION
fix #286

It is because the different ways to calculate hash between `readFieldHash` and `calcHash` (by `byte` or `rune`)

https://github.com/json-iterator/go/blob/10a568c51178f31e41456cedaac7838e0f4f7360/iter_object.go#L49

https://github.com/json-iterator/go/blob/10a568c51178f31e41456cedaac7838e0f4f7360/iter_object.go#L98
