### PR TITLE
Allow private fields to have a custom json tag

### DIFF
--- a/extra/privat_fields.go
+++ b/extra/privat_fields.go
@@ -1,9 +1,10 @@
 package extra
 
 import (
-	"github.com/json-iterator/go"
 	"strings"
 	"unicode"
+
+	"github.com/json-iterator/go"
 )
 
 // SupportPrivateFields include private fields when encoding/decoding
@@ -45,10 +46,12 @@ func calcFieldNames(originalFieldName string, tagProvidedFieldName string, whole
 	} else {
 		fieldNames = []string{tagProvidedFieldName}
 	}
-	// private?
-	isNotExported := unicode.IsLower(rune(originalFieldName[0]))
-	if isNotExported {
+
+	// not private?
+	isExported := unicode.IsUpper(rune(originalFieldName[0]))
+	if isExported {
 		fieldNames = []string{}
 	}
+
 	return fieldNames
 }

--- a/extra/private_fields.go
+++ b/extra/private_fields.go
@@ -46,12 +46,10 @@ func calcFieldNames(originalFieldName string, tagProvidedFieldName string, whole
 	} else {
 		fieldNames = []string{tagProvidedFieldName}
 	}
-
 	// not private?
-	isExported := unicode.IsUpper(rune(originalFieldName[0]))
-	if isExported {
+	isExported := unicode.IsLower(rune(originalFieldName[0]))
+	if !isExported {
 		fieldNames = []string{}
 	}
-
 	return fieldNames
 }

--- a/extra/private_fields_test.go
+++ b/extra/private_fields_test.go
@@ -1,9 +1,10 @@
 package extra
 
 import (
+	"testing"
+
 	"github.com/json-iterator/go"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 func Test_private_fields(t *testing.T) {
@@ -14,5 +15,16 @@ func Test_private_fields(t *testing.T) {
 	should := require.New(t)
 	obj := TestObject{}
 	should.Nil(jsoniter.UnmarshalFromString(`{"field1":"Hello"}`, &obj))
+	should.Equal("Hello", obj.field1)
+}
+
+func Test_private_fields_with_tag(t *testing.T) {
+	type TestObject struct {
+		field1 string `json:"field_1"`
+	}
+	SupportPrivateFields()
+	should := require.New(t)
+	obj := TestObject{}
+	should.Nil(jsoniter.UnmarshalFromString(`{"field_1":"Hello"}`, &obj))
 	should.Equal("Hello", obj.field1)
 }

--- a/extra/private_fields_test.go
+++ b/extra/private_fields_test.go
@@ -28,3 +28,14 @@ func Test_private_fields_with_tag(t *testing.T) {
 	should.Nil(jsoniter.UnmarshalFromString(`{"field_1":"Hello"}`, &obj))
 	should.Equal("Hello", obj.field1)
 }
+
+func Test_private_fields_with_empty_tag(t *testing.T) {
+	type TestObject struct {
+		field1 string `json:""`
+	}
+	SupportPrivateFields()
+	should := require.New(t)
+	obj := TestObject{}
+	should.Nil(jsoniter.UnmarshalFromString(`{"field1":"Hello"}`, &obj))
+	should.Equal("Hello", obj.field1)
+}


### PR DESCRIPTION
I was trying to use the library to be able to have a struct with private fields but that could support custom json tags as well.

This proposal is just to include one more possibility in the parsing from json.

```go
type (
      WithoutCustomJSONTag struct {
            name string
      }

      WithCustomJSONTag struct {
            name string `json:"full_name"`
      }
)

without := WithoutCustomJSONTag{}
with := WithCustomJSONTag{}

extra.SupportPrivateFields()
jsoniter.UnmarshalFromString(`{"name":"Foo"}`, &without)
jsoniter.UnmarshalFromString(`{"full_name":"Foo"}`, &with)

fmt.Println(`Without custom tag, name: `, without.name) // Foo
fmt.Println(`With custom tag, name: `, with.name) // Foo
```