### PR TITLE
optimize: avoid to allocate tmp object for twice

### DIFF
--- a/config.go
+++ b/config.go
@@ -300,10 +300,7 @@ func (cfg *frozenConfig) Marshal(v interface{}) ([]byte, error) {
 	if stream.Error != nil {
 		return nil, stream.Error
 	}
-	result := stream.Buffer()
-	copied := make([]byte, len(result))
-	copy(copied, result)
-	return copied, nil
+	return stream.Buffer(), nil
 }
 
 func (cfg *frozenConfig) MarshalIndent(v interface{}, prefix, indent string) ([]byte, error) {


### PR DESCRIPTION
防止多次不用分配两次内存，stream.buf指为nil，则返回的[]byte值使用了前者已分配的内存空间。自测目前没有影响

运行1小时，优化前：
![image](https://user-images.githubusercontent.com/20457624/49275326-f4e97a80-f4b5-11e8-821a-833bbbab7a67.png)
运行1小时，优化后：
![image](https://user-images.githubusercontent.com/20457624/49276306-1009b980-f4b9-11e8-995a-d33a62e4a3b4.png)
