### PR TITLE
增加对json Marsharl递归层级的判断

### DIFF
--- a/any.go
+++ b/any.go
@@ -291,7 +291,11 @@ func (codec *anyCodec) Decode(ptr unsafe.Pointer, iter *Iterator) {
 	panic("not implemented")
 }
 
-func (codec *anyCodec) Encode(ptr unsafe.Pointer, stream *Stream) {
+func (codec *anyCodec) Encode(ptr unsafe.Pointer, stream *Stream, level int) {
+	if level > 	DefaultMaxRecursiveLevel{
+		stream.Error = MarshalLevelTooDeepErr
+		return
+	}
 	obj := codec.valType.UnsafeIndirect(ptr)
 	any := obj.(Any)
 	any.WriteTo(stream)
@@ -310,7 +314,11 @@ func (codec *directAnyCodec) Decode(ptr unsafe.Pointer, iter *Iterator) {
 	*(*Any)(ptr) = iter.readAny()
 }
 
-func (codec *directAnyCodec) Encode(ptr unsafe.Pointer, stream *Stream) {
+func (codec *directAnyCodec) Encode(ptr unsafe.Pointer, stream *Stream, level int) {
+	if level > 	DefaultMaxRecursiveLevel{
+		stream.Error = MarshalLevelTooDeepErr
+		return
+	}
 	any := *(*Any)(ptr)
 	if any == nil {
 		stream.WriteNil()

--- a/config.go
+++ b/config.go
@@ -184,7 +184,7 @@ func (cfg Config) frozeWithCacheReuse(extraExtensions []Extension) *frozenConfig
 }
 
 func (cfg *frozenConfig) validateJsonRawMessage(extension EncoderExtension) {
-	encoder := &funcEncoder{func(ptr unsafe.Pointer, stream *Stream) {
+	encoder := &funcEncoder{func(ptr unsafe.Pointer, stream *Stream, level int) {
 		rawMessage := *(*json.RawMessage)(ptr)
 		iter := cfg.BorrowIterator([]byte(rawMessage))
 		iter.Read()

--- a/extension_tests/decoder_test.go
+++ b/extension_tests/decoder_test.go
@@ -2,7 +2,7 @@ package test
 
 import (
 	"bytes"
-	"github.com/json-iterator/go"
+	"github.com/vearne/json-iterator-go"
 	"github.com/stretchr/testify/require"
 	"strconv"
 	"testing"
@@ -36,7 +36,7 @@ func Test_customize_byte_array_encoder(t *testing.T) {
 	t.Skip()
 	//jsoniter.ConfigDefault.(*frozenConfig).cleanEncoders()
 	should := require.New(t)
-	jsoniter.RegisterTypeEncoderFunc("[]uint8", func(ptr unsafe.Pointer, stream *jsoniter.Stream) {
+	jsoniter.RegisterTypeEncoderFunc("[]uint8", func(ptr unsafe.Pointer, stream *jsoniter.Stream, level int) {
 		t := *((*[]byte)(ptr))
 		stream.WriteString(string(t))
 	}, nil)

--- a/extra/binary_as_string_codec.go
+++ b/extra/binary_as_string_codec.go
@@ -1,7 +1,7 @@
 package extra
 
 import (
-	".."
+	"github.com/vearne/json-iterator-go"
 	"github.com/modern-go/reflect2"
 	"unicode/utf8"
 	"unsafe"

--- a/extra/binary_as_string_codec.go
+++ b/extra/binary_as_string_codec.go
@@ -1,7 +1,7 @@
 package extra
 
 import (
-	"github.com/json-iterator/go"
+	".."
 	"github.com/modern-go/reflect2"
 	"unicode/utf8"
 	"unsafe"
@@ -163,7 +163,11 @@ func (codec *binaryAsStringCodec) Decode(ptr unsafe.Pointer, iter *jsoniter.Iter
 func (codec *binaryAsStringCodec) IsEmpty(ptr unsafe.Pointer) bool {
 	return len(*((*[]byte)(ptr))) == 0
 }
-func (codec *binaryAsStringCodec) Encode(ptr unsafe.Pointer, stream *jsoniter.Stream) {
+func (codec *binaryAsStringCodec) Encode(ptr unsafe.Pointer, stream *jsoniter.Stream, level int) {
+	if level > 	jsoniter.DefaultMaxRecursiveLevel{
+		stream.Error = jsoniter.MarshalLevelTooDeepErr
+		return
+	}
 	newBuffer := writeBytes(stream.Buffer(), *(*[]byte)(ptr))
 	stream.SetBuffer(newBuffer)
 }

--- a/extra/binary_as_string_codec_test.go
+++ b/extra/binary_as_string_codec_test.go
@@ -1,7 +1,7 @@
 package extra
 
 import (
-	"github.com/json-iterator/go"
+	"github.com/vearne/json-iterator-go"
 	"github.com/stretchr/testify/require"
 	"testing"
 )

--- a/extra/time_as_int64_codec.go
+++ b/extra/time_as_int64_codec.go
@@ -1,7 +1,7 @@
 package extra
 
 import (
-	".."
+	"github.com/vearne/json-iterator-go"
 	"time"
 	"unsafe"
 )

--- a/extra/time_as_int64_codec.go
+++ b/extra/time_as_int64_codec.go
@@ -1,7 +1,7 @@
 package extra
 
 import (
-	"github.com/json-iterator/go"
+	".."
 	"time"
 	"unsafe"
 )
@@ -25,7 +25,11 @@ func (codec *timeAsInt64Codec) IsEmpty(ptr unsafe.Pointer) bool {
 	ts := *((*time.Time)(ptr))
 	return ts.UnixNano() == 0
 }
-func (codec *timeAsInt64Codec) Encode(ptr unsafe.Pointer, stream *jsoniter.Stream) {
+func (codec *timeAsInt64Codec) Encode(ptr unsafe.Pointer, stream *jsoniter.Stream, level int) {
+	if level > 	jsoniter.DefaultMaxRecursiveLevel{
+		stream.Error = jsoniter.MarshalLevelTooDeepErr
+		return
+	}
 	ts := *((*time.Time)(ptr))
 	stream.WriteInt64(ts.UnixNano() / codec.precision.Nanoseconds())
 }

--- a/reflect_array.go
+++ b/reflect_array.go
@@ -24,7 +24,11 @@ func encoderOfArray(ctx *ctx, typ reflect2.Type) ValEncoder {
 
 type emptyArrayEncoder struct{}
 
-func (encoder emptyArrayEncoder) Encode(ptr unsafe.Pointer, stream *Stream) {
+func (encoder emptyArrayEncoder) Encode(ptr unsafe.Pointer, stream *Stream, level int) {
+	if level > 	DefaultMaxRecursiveLevel{
+		stream.Error = MarshalLevelTooDeepErr
+		return
+	}
 	stream.WriteEmptyArray()
 }
 
@@ -37,14 +41,19 @@ type arrayEncoder struct {
 	elemEncoder ValEncoder
 }
 
-func (encoder *arrayEncoder) Encode(ptr unsafe.Pointer, stream *Stream) {
+func (encoder *arrayEncoder) Encode(ptr unsafe.Pointer, stream *Stream, level int) {
+	if level > 	DefaultMaxRecursiveLevel{
+		stream.Error = MarshalLevelTooDeepErr
+		return
+	}
+
 	stream.WriteArrayStart()
 	elemPtr := unsafe.Pointer(ptr)
-	encoder.elemEncoder.Encode(elemPtr, stream)
+	encoder.elemEncoder.Encode(elemPtr, stream, level+1)
 	for i := 1; i < encoder.arrayType.Len(); i++ {
 		stream.WriteMore()
 		elemPtr = encoder.arrayType.UnsafeGetIndex(ptr, i)
-		encoder.elemEncoder.Encode(elemPtr, stream)
+		encoder.elemEncoder.Encode(elemPtr, stream, level+1)
 	}
 	stream.WriteArrayEnd()
 	if stream.Error != nil && stream.Error != io.EOF {

--- a/reflect_dynamic.go
+++ b/reflect_dynamic.go
@@ -10,7 +10,11 @@ type dynamicEncoder struct {
 	valType reflect2.Type
 }
 
-func (encoder *dynamicEncoder) Encode(ptr unsafe.Pointer, stream *Stream) {
+func (encoder *dynamicEncoder) Encode(ptr unsafe.Pointer, stream *Stream, level int) {
+	if level > 	DefaultMaxRecursiveLevel{
+		stream.Error = MarshalLevelTooDeepErr
+		return
+	}
 	obj := encoder.valType.UnsafeIndirect(ptr)
 	stream.WriteVal(obj)
 }

--- a/reflect_extension.go
+++ b/reflect_extension.go
@@ -183,7 +183,7 @@ func (encoder *funcEncoder) Encode(ptr unsafe.Pointer, stream *Stream, level int
 		stream.Error = MarshalLevelTooDeepErr
 		return
 	}
-	encoder.fun(ptr, stream)
+	encoder.fun(ptr, stream, level)
 }
 
 func (encoder *funcEncoder) IsEmpty(ptr unsafe.Pointer) bool {
@@ -197,7 +197,7 @@ func (encoder *funcEncoder) IsEmpty(ptr unsafe.Pointer) bool {
 type DecoderFunc func(ptr unsafe.Pointer, iter *Iterator)
 
 // EncoderFunc the function form of TypeEncoder
-type EncoderFunc func(ptr unsafe.Pointer, stream *Stream)
+type EncoderFunc func(ptr unsafe.Pointer, stream *Stream, level int)
 
 // RegisterTypeDecoderFunc register TypeDecoder for a type with function
 func RegisterTypeDecoderFunc(typ string, fun DecoderFunc) {

--- a/reflect_extension.go
+++ b/reflect_extension.go
@@ -178,7 +178,11 @@ type funcEncoder struct {
 	isEmptyFunc func(ptr unsafe.Pointer) bool
 }
 
-func (encoder *funcEncoder) Encode(ptr unsafe.Pointer, stream *Stream) {
+func (encoder *funcEncoder) Encode(ptr unsafe.Pointer, stream *Stream, level int) {
+	if level > 	DefaultMaxRecursiveLevel{
+		stream.Error = MarshalLevelTooDeepErr
+		return
+	}
 	encoder.fun(ptr, stream)
 }
 

--- a/reflect_json_number.go
+++ b/reflect_json_number.go
@@ -70,7 +70,7 @@ func (codec *jsonNumberCodec) Decode(ptr unsafe.Pointer, iter *Iterator) {
 	}
 }
 
-func (codec *jsonNumberCodec) Encode(ptr unsafe.Pointer, stream *Stream) {
+func (codec *jsonNumberCodec) Encode(ptr unsafe.Pointer, stream *Stream, level int) {
 	number := *((*json.Number)(ptr))
 	if len(number) == 0 {
 		stream.writeByte('0')
@@ -98,7 +98,12 @@ func (codec *jsoniterNumberCodec) Decode(ptr unsafe.Pointer, iter *Iterator) {
 	}
 }
 
-func (codec *jsoniterNumberCodec) Encode(ptr unsafe.Pointer, stream *Stream) {
+func (codec *jsoniterNumberCodec) Encode(ptr unsafe.Pointer, stream *Stream, level int) {
+	if level > 	DefaultMaxRecursiveLevel{
+		stream.Error = MarshalLevelTooDeepErr
+		return
+	}
+
 	number := *((*Number)(ptr))
 	if len(number) == 0 {
 		stream.writeByte('0')

--- a/reflect_json_raw_message.go
+++ b/reflect_json_raw_message.go
@@ -36,7 +36,11 @@ func (codec *jsonRawMessageCodec) Decode(ptr unsafe.Pointer, iter *Iterator) {
 	*((*json.RawMessage)(ptr)) = json.RawMessage(iter.SkipAndReturnBytes())
 }
 
-func (codec *jsonRawMessageCodec) Encode(ptr unsafe.Pointer, stream *Stream) {
+func (codec *jsonRawMessageCodec) Encode(ptr unsafe.Pointer, stream *Stream, level int) {
+	if level > 	DefaultMaxRecursiveLevel{
+		stream.Error = MarshalLevelTooDeepErr
+		return
+	}
 	stream.WriteRaw(string(*((*json.RawMessage)(ptr))))
 }
 
@@ -51,7 +55,11 @@ func (codec *jsoniterRawMessageCodec) Decode(ptr unsafe.Pointer, iter *Iterator)
 	*((*RawMessage)(ptr)) = RawMessage(iter.SkipAndReturnBytes())
 }
 
-func (codec *jsoniterRawMessageCodec) Encode(ptr unsafe.Pointer, stream *Stream) {
+func (codec *jsoniterRawMessageCodec) Encode(ptr unsafe.Pointer, stream *Stream, level int) {
+	if level > 	DefaultMaxRecursiveLevel{
+		stream.Error = MarshalLevelTooDeepErr
+		return
+	}
 	stream.WriteRaw(string(*((*RawMessage)(ptr))))
 }
 

--- a/reflect_map.go
+++ b/reflect_map.go
@@ -217,9 +217,13 @@ type numericMapKeyEncoder struct {
 	encoder ValEncoder
 }
 
-func (encoder *numericMapKeyEncoder) Encode(ptr unsafe.Pointer, stream *Stream) {
+func (encoder *numericMapKeyEncoder) Encode(ptr unsafe.Pointer, stream *Stream, level int) {
+	if level > 	DefaultMaxRecursiveLevel{
+		stream.Error = MarshalLevelTooDeepErr
+		return
+	}
 	stream.writeByte('"')
-	encoder.encoder.Encode(ptr, stream)
+	encoder.encoder.Encode(ptr, stream, level)
 	stream.writeByte('"')
 }
 
@@ -232,9 +236,13 @@ type dynamicMapKeyEncoder struct {
 	valType reflect2.Type
 }
 
-func (encoder *dynamicMapKeyEncoder) Encode(ptr unsafe.Pointer, stream *Stream) {
+func (encoder *dynamicMapKeyEncoder) Encode(ptr unsafe.Pointer, stream *Stream, level int) {
+	if level > 	DefaultMaxRecursiveLevel{
+		stream.Error = MarshalLevelTooDeepErr
+		return
+	}
 	obj := encoder.valType.UnsafeIndirect(ptr)
-	encoderOfMapKey(encoder.ctx, reflect2.TypeOf(obj)).Encode(reflect2.PtrOf(obj), stream)
+	encoderOfMapKey(encoder.ctx, reflect2.TypeOf(obj)).Encode(reflect2.PtrOf(obj), stream, level)
 }
 
 func (encoder *dynamicMapKeyEncoder) IsEmpty(ptr unsafe.Pointer) bool {
@@ -248,7 +256,12 @@ type mapEncoder struct {
 	elemEncoder ValEncoder
 }
 
-func (encoder *mapEncoder) Encode(ptr unsafe.Pointer, stream *Stream) {
+func (encoder *mapEncoder) Encode(ptr unsafe.Pointer, stream *Stream, level int) {
+	if level > 	DefaultMaxRecursiveLevel{
+		stream.Error = MarshalLevelTooDeepErr
+		return
+	}
+
 	stream.WriteObjectStart()
 	iter := encoder.mapType.UnsafeIterate(ptr)
 	for i := 0; iter.HasNext(); i++ {
@@ -256,13 +269,13 @@ func (encoder *mapEncoder) Encode(ptr unsafe.Pointer, stream *Stream) {
 			stream.WriteMore()
 		}
 		key, elem := iter.UnsafeNext()
-		encoder.keyEncoder.Encode(key, stream)
+		encoder.keyEncoder.Encode(key, stream, level+1)
 		if stream.indention > 0 {
 			stream.writeTwoBytes(byte(':'), byte(' '))
 		} else {
 			stream.writeByte(':')
 		}
-		encoder.elemEncoder.Encode(elem, stream)
+		encoder.elemEncoder.Encode(elem, stream, level+1)
 	}
 	stream.WriteObjectEnd()
 }
@@ -278,7 +291,12 @@ type sortKeysMapEncoder struct {
 	elemEncoder ValEncoder
 }
 
-func (encoder *sortKeysMapEncoder) Encode(ptr unsafe.Pointer, stream *Stream) {
+func (encoder *sortKeysMapEncoder) Encode(ptr unsafe.Pointer, stream *Stream, level int) {
+	if level > 	DefaultMaxRecursiveLevel{
+		stream.Error = MarshalLevelTooDeepErr
+		return
+	}
+
 	if *(*unsafe.Pointer)(ptr) == nil {
 		stream.WriteNil()
 		return
@@ -291,7 +309,7 @@ func (encoder *sortKeysMapEncoder) Encode(ptr unsafe.Pointer, stream *Stream) {
 	for mapIter.HasNext() {
 		subStream.buf = make([]byte, 0, 64)
 		key, elem := mapIter.UnsafeNext()
-		encoder.keyEncoder.Encode(key, subStream)
+		encoder.keyEncoder.Encode(key, subStream, level+1)
 		if subStream.Error != nil && subStream.Error != io.EOF && stream.Error == nil {
 			stream.Error = subStream.Error
 		}
@@ -303,7 +321,7 @@ func (encoder *sortKeysMapEncoder) Encode(ptr unsafe.Pointer, stream *Stream) {
 		} else {
 			subStream.writeByte(':')
 		}
-		encoder.elemEncoder.Encode(elem, subStream)
+		encoder.elemEncoder.Encode(elem, subStream, level+1)
 		keyValues = append(keyValues, encodedKV{
 			key:      decodedKey,
 			keyValue: subStream.Buffer(),

--- a/reflect_marshaler.go
+++ b/reflect_marshaler.go
@@ -87,7 +87,12 @@ type marshalerEncoder struct {
 	valType      reflect2.Type
 }
 
-func (encoder *marshalerEncoder) Encode(ptr unsafe.Pointer, stream *Stream) {
+func (encoder *marshalerEncoder) Encode(ptr unsafe.Pointer, stream *Stream, level int) {
+	if level > 	DefaultMaxRecursiveLevel{
+		stream.Error = MarshalLevelTooDeepErr
+		return
+	}
+
 	obj := encoder.valType.UnsafeIndirect(ptr)
 	if encoder.valType.IsNullable() && reflect2.IsNil(obj) {
 		stream.WriteNil()
@@ -110,7 +115,12 @@ type directMarshalerEncoder struct {
 	checkIsEmpty checkIsEmpty
 }
 
-func (encoder *directMarshalerEncoder) Encode(ptr unsafe.Pointer, stream *Stream) {
+func (encoder *directMarshalerEncoder) Encode(ptr unsafe.Pointer, stream *Stream, level int) {
+	if level > 	DefaultMaxRecursiveLevel{
+		stream.Error = MarshalLevelTooDeepErr
+		return
+	}
+
 	marshaler := *(*json.Marshaler)(ptr)
 	if marshaler == nil {
 		stream.WriteNil()
@@ -134,7 +144,12 @@ type textMarshalerEncoder struct {
 	checkIsEmpty  checkIsEmpty
 }
 
-func (encoder *textMarshalerEncoder) Encode(ptr unsafe.Pointer, stream *Stream) {
+func (encoder *textMarshalerEncoder) Encode(ptr unsafe.Pointer, stream *Stream, level int) {
+	if level > 	DefaultMaxRecursiveLevel{
+		stream.Error = MarshalLevelTooDeepErr
+		return
+	}
+
 	obj := encoder.valType.UnsafeIndirect(ptr)
 	if encoder.valType.IsNullable() && reflect2.IsNil(obj) {
 		stream.WriteNil()
@@ -146,7 +161,7 @@ func (encoder *textMarshalerEncoder) Encode(ptr unsafe.Pointer, stream *Stream) 
 		stream.Error = err
 	} else {
 		str := string(bytes)
-		encoder.stringEncoder.Encode(unsafe.Pointer(&str), stream)
+		encoder.stringEncoder.Encode(unsafe.Pointer(&str), stream, level)
 	}
 }
 
@@ -159,7 +174,12 @@ type directTextMarshalerEncoder struct {
 	checkIsEmpty  checkIsEmpty
 }
 
-func (encoder *directTextMarshalerEncoder) Encode(ptr unsafe.Pointer, stream *Stream) {
+func (encoder *directTextMarshalerEncoder) Encode(ptr unsafe.Pointer, stream *Stream, level int) {
+	if level > 	DefaultMaxRecursiveLevel{
+		stream.Error = MarshalLevelTooDeepErr
+		return
+	}
+
 	marshaler := *(*encoding.TextMarshaler)(ptr)
 	if marshaler == nil {
 		stream.WriteNil()
@@ -170,7 +190,7 @@ func (encoder *directTextMarshalerEncoder) Encode(ptr unsafe.Pointer, stream *St
 		stream.Error = err
 	} else {
 		str := string(bytes)
-		encoder.stringEncoder.Encode(unsafe.Pointer(&str), stream)
+		encoder.stringEncoder.Encode(unsafe.Pointer(&str), stream, level)
 	}
 }
 

--- a/reflect_native.go
+++ b/reflect_native.go
@@ -209,7 +209,12 @@ func (codec *stringCodec) Decode(ptr unsafe.Pointer, iter *Iterator) {
 	*((*string)(ptr)) = iter.ReadString()
 }
 
-func (codec *stringCodec) Encode(ptr unsafe.Pointer, stream *Stream) {
+func (codec *stringCodec) Encode(ptr unsafe.Pointer, stream *Stream, level int) {
+	if level > 	DefaultMaxRecursiveLevel{
+		stream.Error = MarshalLevelTooDeepErr
+		return
+	}
+
 	str := *((*string)(ptr))
 	stream.WriteString(str)
 }
@@ -227,7 +232,11 @@ func (codec *int8Codec) Decode(ptr unsafe.Pointer, iter *Iterator) {
 	}
 }
 
-func (codec *int8Codec) Encode(ptr unsafe.Pointer, stream *Stream) {
+func (codec *int8Codec) Encode(ptr unsafe.Pointer, stream *Stream, level int) {
+	if level > 	DefaultMaxRecursiveLevel{
+		stream.Error = MarshalLevelTooDeepErr
+		return
+	}
 	stream.WriteInt8(*((*int8)(ptr)))
 }
 
@@ -244,7 +253,11 @@ func (codec *int16Codec) Decode(ptr unsafe.Pointer, iter *Iterator) {
 	}
 }
 
-func (codec *int16Codec) Encode(ptr unsafe.Pointer, stream *Stream) {
+func (codec *int16Codec) Encode(ptr unsafe.Pointer, stream *Stream, level int) {
+	if level > 	DefaultMaxRecursiveLevel{
+		stream.Error = MarshalLevelTooDeepErr
+		return
+	}
 	stream.WriteInt16(*((*int16)(ptr)))
 }
 
@@ -261,7 +274,11 @@ func (codec *int32Codec) Decode(ptr unsafe.Pointer, iter *Iterator) {
 	}
 }
 
-func (codec *int32Codec) Encode(ptr unsafe.Pointer, stream *Stream) {
+func (codec *int32Codec) Encode(ptr unsafe.Pointer, stream *Stream, level int) {
+	if level > 	DefaultMaxRecursiveLevel{
+		stream.Error = MarshalLevelTooDeepErr
+		return
+	}
 	stream.WriteInt32(*((*int32)(ptr)))
 }
 
@@ -278,7 +295,11 @@ func (codec *int64Codec) Decode(ptr unsafe.Pointer, iter *Iterator) {
 	}
 }
 
-func (codec *int64Codec) Encode(ptr unsafe.Pointer, stream *Stream) {
+func (codec *int64Codec) Encode(ptr unsafe.Pointer, stream *Stream, level int) {
+	if level > 	DefaultMaxRecursiveLevel{
+		stream.Error = MarshalLevelTooDeepErr
+		return
+	}
 	stream.WriteInt64(*((*int64)(ptr)))
 }
 
@@ -295,7 +316,11 @@ func (codec *uint8Codec) Decode(ptr unsafe.Pointer, iter *Iterator) {
 	}
 }
 
-func (codec *uint8Codec) Encode(ptr unsafe.Pointer, stream *Stream) {
+func (codec *uint8Codec) Encode(ptr unsafe.Pointer, stream *Stream, level int) {
+	if level > 	DefaultMaxRecursiveLevel{
+		stream.Error = MarshalLevelTooDeepErr
+		return
+	}
 	stream.WriteUint8(*((*uint8)(ptr)))
 }
 
@@ -312,7 +337,11 @@ func (codec *uint16Codec) Decode(ptr unsafe.Pointer, iter *Iterator) {
 	}
 }
 
-func (codec *uint16Codec) Encode(ptr unsafe.Pointer, stream *Stream) {
+func (codec *uint16Codec) Encode(ptr unsafe.Pointer, stream *Stream, level int) {
+	if level > 	DefaultMaxRecursiveLevel{
+		stream.Error = MarshalLevelTooDeepErr
+		return
+	}
 	stream.WriteUint16(*((*uint16)(ptr)))
 }
 
@@ -329,7 +358,11 @@ func (codec *uint32Codec) Decode(ptr unsafe.Pointer, iter *Iterator) {
 	}
 }
 
-func (codec *uint32Codec) Encode(ptr unsafe.Pointer, stream *Stream) {
+func (codec *uint32Codec) Encode(ptr unsafe.Pointer, stream *Stream, level int) {
+	if level > 	DefaultMaxRecursiveLevel{
+		stream.Error = MarshalLevelTooDeepErr
+		return
+	}
 	stream.WriteUint32(*((*uint32)(ptr)))
 }
 
@@ -346,7 +379,11 @@ func (codec *uint64Codec) Decode(ptr unsafe.Pointer, iter *Iterator) {
 	}
 }
 
-func (codec *uint64Codec) Encode(ptr unsafe.Pointer, stream *Stream) {
+func (codec *uint64Codec) Encode(ptr unsafe.Pointer, stream *Stream, level int) {
+	if level > 	DefaultMaxRecursiveLevel{
+		stream.Error = MarshalLevelTooDeepErr
+		return
+	}
 	stream.WriteUint64(*((*uint64)(ptr)))
 }
 
@@ -363,7 +400,11 @@ func (codec *float32Codec) Decode(ptr unsafe.Pointer, iter *Iterator) {
 	}
 }
 
-func (codec *float32Codec) Encode(ptr unsafe.Pointer, stream *Stream) {
+func (codec *float32Codec) Encode(ptr unsafe.Pointer, stream *Stream, level int) {
+	if level > 	DefaultMaxRecursiveLevel{
+		stream.Error = MarshalLevelTooDeepErr
+		return
+	}
 	stream.WriteFloat32(*((*float32)(ptr)))
 }
 
@@ -380,7 +421,11 @@ func (codec *float64Codec) Decode(ptr unsafe.Pointer, iter *Iterator) {
 	}
 }
 
-func (codec *float64Codec) Encode(ptr unsafe.Pointer, stream *Stream) {
+func (codec *float64Codec) Encode(ptr unsafe.Pointer, stream *Stream, level int) {
+	if level > 	DefaultMaxRecursiveLevel{
+		stream.Error = MarshalLevelTooDeepErr
+		return
+	}
 	stream.WriteFloat64(*((*float64)(ptr)))
 }
 
@@ -397,7 +442,11 @@ func (codec *boolCodec) Decode(ptr unsafe.Pointer, iter *Iterator) {
 	}
 }
 
-func (codec *boolCodec) Encode(ptr unsafe.Pointer, stream *Stream) {
+func (codec *boolCodec) Encode(ptr unsafe.Pointer, stream *Stream, level int) {
+	if level > 	DefaultMaxRecursiveLevel{
+		stream.Error = MarshalLevelTooDeepErr
+		return
+	}
 	stream.WriteBool(*((*bool)(ptr)))
 }
 
@@ -431,7 +480,11 @@ func (codec *base64Codec) Decode(ptr unsafe.Pointer, iter *Iterator) {
 	}
 }
 
-func (codec *base64Codec) Encode(ptr unsafe.Pointer, stream *Stream) {
+func (codec *base64Codec) Encode(ptr unsafe.Pointer, stream *Stream, level int) {
+	if level > 	DefaultMaxRecursiveLevel{
+		stream.Error = MarshalLevelTooDeepErr
+		return
+	}
 	src := *((*[]byte)(ptr))
 	if len(src) == 0 {
 		stream.WriteNil()


### PR DESCRIPTION
增加对json Marsharl递归层级的判断，最大不允许超过1000层