### PR TITLE
Add object iterator that avoids string allocation

### DIFF
--- a/iter_object.go
+++ b/iter_object.go
@@ -107,15 +107,18 @@ func calcHash(str string, caseSensitive bool) int64 {
 	return int64(hash)
 }
 
-// ReadObjectCB read object with callback, the key is ascii only and field name not copied
-func (iter *Iterator) ReadObjectCB(callback func(*Iterator, string) bool) bool {
+// ReadObjectCBWithoutCopy read object with callback, the key is ascii only,
+// and it will be changed in the next iterator call. The callback function must
+// make a copy of the key if needs to live beyond the scope of the callback.
+func (iter *Iterator) ReadObjectCBWithoutCopy(callback func(*Iterator,
+	[]byte) bool) bool {
 	c := iter.nextToken()
-	var field string
+	var field []byte
 	if c == '{' {
 		c = iter.nextToken()
 		if c == '"' {
 			iter.unreadByte()
-			field = iter.ReadString()
+			field = iter.ReadStringAsSlice()
 			c = iter.nextToken()
 			if c != ':' {
 				iter.ReportError("ReadObject", "expect : after object field, but found "+string([]byte{c}))
@@ -125,7 +128,7 @@ func (iter *Iterator) ReadObjectCB(callback func(*Iterator, string) bool) bool {
 			}
 			c = iter.nextToken()
 			for c == ',' {
-				field = iter.ReadString()
+				field = iter.ReadStringAsSlice()
 				c = iter.nextToken()
 				if c != ':' {
 					iter.ReportError("ReadObject", "expect : after object field, but found "+string([]byte{c}))
@@ -153,6 +156,13 @@ func (iter *Iterator) ReadObjectCB(callback func(*Iterator, string) bool) bool {
 	}
 	iter.ReportError("ReadObjectCB", `expect { or n, but found `+string([]byte{c}))
 	return false
+}
+
+// ReadObjectCB read object with callback, the key is ascii only.
+func (iter *Iterator) ReadObjectCB(callback func(*Iterator, string) bool) bool {
+	return iter.ReadObjectCBNoCopy(func(it *Iterator, field []byte) bool {
+		return callback(it, string(field))
+	})
 }
 
 // ReadMapCB read map with callback, the key can be any string


### PR DESCRIPTION
Adds a version of `ReadObjectCB` (`ReadObjectCBWithoutCopy`) that uses a
byte-slice key instead of a string, which avoids the allocation of a
string object for each callback.