### PR TITLE
feat: add EmitDefaults option,able to ignore omitempty tag.

### DIFF
--- a/config.go
+++ b/config.go
@@ -25,6 +25,7 @@ type Config struct {
 	ValidateJsonRawMessage        bool
 	ObjectFieldMustBeSimpleString bool
 	CaseSensitive                 bool
+	EmitDefaults                  bool
 }
 
 // API the public interface of this package.
@@ -80,6 +81,7 @@ type frozenConfig struct {
 	streamPool                    *sync.Pool
 	iteratorPool                  *sync.Pool
 	caseSensitive                 bool
+	emitDefaults                  bool
 }
 
 func (cfg *frozenConfig) initCache() {
@@ -134,6 +136,7 @@ func (cfg Config) Froze() API {
 		onlyTaggedField:               cfg.OnlyTaggedField,
 		disallowUnknownFields:         cfg.DisallowUnknownFields,
 		caseSensitive:                 cfg.CaseSensitive,
+		emitDefaults:                  cfg.EmitDefaults,
 	}
 	api.streamPool = &sync.Pool{
 		New: func() interface{} {

--- a/config.go
+++ b/config.go
@@ -6,7 +6,7 @@ import (
 	"reflect"
 	"sync"
 	"unsafe"
-
+	
 	"github.com/modern-go/concurrent"
 	"github.com/modern-go/reflect2"
 )
@@ -26,6 +26,7 @@ type Config struct {
 	ObjectFieldMustBeSimpleString bool
 	CaseSensitive                 bool
 	EmitDefaults                  bool
+	OrigName                      bool
 }
 
 // API the public interface of this package.
@@ -82,6 +83,7 @@ type frozenConfig struct {
 	iteratorPool                  *sync.Pool
 	caseSensitive                 bool
 	emitDefaults                  bool
+	origName                      bool
 }
 
 func (cfg *frozenConfig) initCache() {
@@ -137,6 +139,7 @@ func (cfg Config) Froze() API {
 		disallowUnknownFields:         cfg.DisallowUnknownFields,
 		caseSensitive:                 cfg.CaseSensitive,
 		emitDefaults:                  cfg.EmitDefaults,
+		origName:                      cfg.OrigName,
 	}
 	api.streamPool = &sync.Pool{
 		New: func() interface{} {

--- a/reflect_extension.go
+++ b/reflect_extension.go
@@ -2,12 +2,13 @@ package jsoniter
 
 import (
 	"fmt"
-	"github.com/modern-go/reflect2"
 	"reflect"
 	"sort"
 	"strings"
 	"unicode"
 	"unsafe"
+
+	"github.com/modern-go/reflect2"
 )
 
 var typeDecoders = map[string]ValDecoder{}
@@ -446,7 +447,9 @@ func processTags(structDescriptor *StructDescriptor, cfg *frozenConfig) {
 		tagParts := strings.Split(binding.Field.Tag().Get(cfg.getTagKey()), ",")
 		for _, tagPart := range tagParts[1:] {
 			if tagPart == "omitempty" {
-				shouldOmitEmpty = true
+				if cfg.emitDefaults == false {
+					shouldOmitEmpty = true
+				}
 			} else if tagPart == "string" {
 				if binding.Field.Type().Kind() == reflect.String {
 					binding.Decoder = &stringModeStringDecoder{binding.Decoder, cfg}

--- a/reflect_extension.go
+++ b/reflect_extension.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"unicode"
 	"unsafe"
-
+	
 	"github.com/modern-go/reflect2"
 )
 
@@ -374,7 +374,7 @@ func describeStruct(ctx *ctx, typ reflect2.Type) *StructDescriptor {
 				}
 			}
 		}
-		fieldNames := calcFieldNames(field.Name(), tagParts[0], tag)
+		fieldNames := calcFieldNames(ctx, field.Name(), tagParts[0], tag)
 		fieldCacheKey := fmt.Sprintf("%s/%s", typ.String(), field.Name())
 		decoder := fieldDecoders[fieldCacheKey]
 		if decoder == nil {
@@ -465,14 +465,14 @@ func processTags(structDescriptor *StructDescriptor, cfg *frozenConfig) {
 	}
 }
 
-func calcFieldNames(originalFieldName string, tagProvidedFieldName string, wholeTag string) []string {
+func calcFieldNames(ctx *ctx, originalFieldName string, tagProvidedFieldName string, wholeTag string) []string {
 	// ignore?
 	if wholeTag == "-" {
 		return []string{}
 	}
 	// rename?
 	var fieldNames []string
-	if tagProvidedFieldName == "" {
+	if ctx.origName == true || tagProvidedFieldName == "" {
 		fieldNames = []string{originalFieldName}
 	} else {
 		fieldNames = []string{tagProvidedFieldName}


### PR DESCRIPTION
for some reason like grpc rpoto generaed code need to ignore json tag
`omitempty` json tag is hard-coded into the protoc-gen-go [source](https://github.com/golang/protobuf/blob/master/protoc-gen-go/generator/generator.go#L2243) 
```go
tag := fmt.Sprintf("protobuf:%s json:%q", g.goTag(message, field, wiretype), jsonName+",omitempty")
```