### PR TITLE
Fix unmarshal into nil interface

### DIFF
--- a/reflect.go
+++ b/reflect.go
@@ -64,7 +64,7 @@ func (iter *Iterator) ReadVal(obj interface{}) {
 	decoder := iter.cfg.getDecoderFromCache(cacheKey)
 	if decoder == nil {
 		typ := reflect2.TypeOf(obj)
-		if typ.Kind() != reflect.Ptr {
+		if typ == nil || typ.Kind() != reflect.Ptr {
 			iter.ReportError("ReadVal", "can only unmarshal into pointer")
 			return
 		}


### PR DESCRIPTION
The following sequence panics:

gore> :import "github.com/json-iterator/go"
gore> var v interface{}
gore> jsoniter.Unmarshal([]byte(`{}`), v)
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x40 pc=0x11562dd]

goroutine 1 [running]:
github.com/json-iterator/go.(*Iterator).ReadVal(0xc0000ca000, 0x0, 0x0)
	/Users/***/go/pkg/mod/github.com/json-iterator/go@v1.1.5/reflect.go:67 +0x12d
github.com/json-iterator/go.(*frozenConfig).Unmarshal(0xc0000bc000, 0xc00009e1a8, 0x2, 0x2, 0x0, 0x0, 0x0, 0x0)
	/Users/***/go/pkg/mod/github.com/json-iterator/go@v1.1.5/config.go:348 +0xb0
github.com/json-iterator/go.Unmarshal(...)
	/Users/***/go/pkg/mod/github.com/json-iterator/go@v1.1.5/adapter.go:16
main.main()
+0x76