### PR TITLE
Add Iterator.StringReader()

### DIFF
--- a/iter_str_reader.go
+++ b/iter_str_reader.go
@@ -1,0 +1,53 @@
+package jsoniter
+
+import "io"
+
+type stringReader struct {
+	eof  bool
+	iter *Iterator
+}
+
+// Read implements io.Reader. There is no provision for resetting the reader
+// after EOF, nor for ensuring that the full JSON string is read to its end.
+func (r *stringReader) Read(p []byte) (n int, err error) {
+	if r.eof {
+		return 0, io.EOF
+	}
+	p = p[:0]
+	iter := r.iter
+	for iter.Error == nil && len(p) < cap(p) {
+		c := iter.readByte()
+		if c == '"' {
+			r.eof = true
+			break
+		}
+		if c == '\\' {
+			// if we don't have room for 2 runes, leave it for the next call
+			if len(p)+8 > cap(p) {
+				iter.unreadByte()
+				break
+			}
+			c = iter.readByte()
+			p = iter.readEscapedChar(c, p)
+		} else {
+			p = append(p, c)
+		}
+	}
+	return len(p), nil
+}
+
+// StringReader provides an io.Reader for the upcoming JSON string value. The
+// consumer absolutely MUST consume the entire string in order to preserve the
+// state of the Iterator. If the next value in the JSON stream is not a string,
+// the returned reader will be nil.
+func (iter *Iterator) StringReader() io.Reader {
+	c := iter.nextToken()
+	if c == '"' {
+		return &stringReader{iter: iter}
+	} else if c == 'n' {
+		iter.skipThreeBytes('u', 'l', 'l')
+		return nil
+	}
+	iter.ReportError("StringReader", `expects " or n, but found `+string([]byte{c}))
+	return nil
+}


### PR DESCRIPTION
Add `Iterator.StringReader()` to allow consumers to stream a JSON string without copying to unnecessary buffers.

I fully expect this PR to probably be at least initially rejected, since I have provided neither a reliable means, nor documentation with sufficiently scary warnings, to avoid letting the consumer fail to read the full string, which in turn obviously ruins the state of the Iterator/Decoder.

However, I do think it's a decent starting point toward letting consumers avoid large buffer use in the case that an interesting and streamable large blob happens to be a JSON string in the bytestream. I do think it's at least in the spirit of this library, or I wouldn't be posting a PR at all.

I do also intend to add proper commentary and docs eventually, but it may take me some time to get to it, so if anybody were interested in taking a stab first, I'd be very grateful to hear that in the rejection message for this request :-)

For now, I'm using this in a personal project, and ensuring that I `io.Reader.Read(...)` through the entire JSON string by being explicit about that, but I thought I'd share this rather than keep it to myself, as it seems to be helpful. Please let me know if an example of how this has proved useful would perhaps lean folks in the direction of including this after all.