### PR TITLE
Using strings.Builder in golang v1.10 to reduce memory allocations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
-  - 1.8.x
+  - 1.10.x
   - 1.x
 
 before_install:

--- a/config.go
+++ b/config.go
@@ -8,7 +8,6 @@ import (
 	"sync"
 	"unsafe"
 
-	"github.com/junchih/stringx"
 	"github.com/modern-go/concurrent"
 	"github.com/modern-go/reflect2"
 )
@@ -82,7 +81,6 @@ type frozenConfig struct {
 	streamPool                    *sync.Pool
 	iteratorPool                  *sync.Pool
 	stringBuilderPool             *sync.Pool
-	stringFactoryPool             *sync.Pool
 	caseSensitive                 bool
 }
 
@@ -152,11 +150,6 @@ func (cfg Config) Froze() API {
 	api.stringBuilderPool = &sync.Pool{
 		New: func() interface{} {
 			return &strings.Builder{}
-		},
-	}
-	api.stringFactoryPool = &sync.Pool{
-		New: func() interface{} {
-			return stringx.NewFactory()
 		},
 	}
 	api.initCache()

--- a/config.go
+++ b/config.go
@@ -4,9 +4,11 @@ import (
 	"encoding/json"
 	"io"
 	"reflect"
+	"strings"
 	"sync"
 	"unsafe"
 
+	"github.com/junchih/stringx"
 	"github.com/modern-go/concurrent"
 	"github.com/modern-go/reflect2"
 )
@@ -79,6 +81,8 @@ type frozenConfig struct {
 	extraExtensions               []Extension
 	streamPool                    *sync.Pool
 	iteratorPool                  *sync.Pool
+	stringBuilderPool             *sync.Pool
+	stringFactoryPool             *sync.Pool
 	caseSensitive                 bool
 }
 
@@ -143,6 +147,16 @@ func (cfg Config) Froze() API {
 	api.iteratorPool = &sync.Pool{
 		New: func() interface{} {
 			return NewIterator(api)
+		},
+	}
+	api.stringBuilderPool = &sync.Pool{
+		New: func() interface{} {
+			return &strings.Builder{}
+		},
+	}
+	api.stringFactoryPool = &sync.Pool{
+		New: func() interface{} {
+			return stringx.NewFactory()
 		},
 	}
 	api.initCache()

--- a/iter.go
+++ b/iter.go
@@ -3,6 +3,7 @@ package jsoniter
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/junchih/stringx"
 	"io"
 )
 
@@ -72,6 +73,7 @@ type Iterator struct {
 	cfg              *frozenConfig
 	reader           io.Reader
 	buf              []byte
+	strf             *stringx.Factory
 	head             int
 	tail             int
 	captureStartedAt int
@@ -86,6 +88,7 @@ func NewIterator(cfg API) *Iterator {
 		cfg:    cfg.(*frozenConfig),
 		reader: nil,
 		buf:    nil,
+		strf:   stringx.NewFactory(),
 		head:   0,
 		tail:   0,
 	}
@@ -97,6 +100,7 @@ func Parse(cfg API, reader io.Reader, bufSize int) *Iterator {
 		cfg:    cfg.(*frozenConfig),
 		reader: reader,
 		buf:    make([]byte, bufSize),
+		strf:   stringx.NewFactory(),
 		head:   0,
 		tail:   0,
 	}
@@ -108,6 +112,7 @@ func ParseBytes(cfg API, input []byte) *Iterator {
 		cfg:    cfg.(*frozenConfig),
 		reader: nil,
 		buf:    input,
+		strf:   stringx.NewFactory(),
 		head:   0,
 		tail:   len(input),
 	}

--- a/iter_str.go
+++ b/iter_str.go
@@ -8,14 +8,12 @@ import (
 
 // ReadString read string from iterator
 func (iter *Iterator) ReadString() (ret string) {
-	strf := iter.cfg.borrowStringFactory()
-	defer iter.cfg.returnStringFactory(strf)
 	c := iter.nextToken()
 	if c == '"' {
 		for i := iter.head; i < iter.tail; i++ {
 			c := iter.buf[i]
 			if c == '"' {
-				ret = strf.NewString(iter.buf[iter.head:i])
+				ret = iter.strf.NewString(iter.buf[iter.head:i])
 				iter.head = i + 1
 				return ret
 			} else if c == '\\' {
@@ -31,7 +29,7 @@ func (iter *Iterator) ReadString() (ret string) {
 		iter.skipThreeBytes('u', 'l', 'l')
 		return ""
 	}
-	iter.ReportError("ReadString", `expects " or n, but found `+strf.NewString([]byte{c}))
+	iter.ReportError("ReadString", `expects " or n, but found `+iter.strf.NewString([]byte{c}))
 	return
 }
 

--- a/misc_tests/jsoniter_nested_test.go
+++ b/misc_tests/jsoniter_nested_test.go
@@ -64,6 +64,20 @@ func Benchmark_jsoniter_nested(b *testing.B) {
 	}
 }
 
+func Benchmark_jsoniter_string(b *testing.B) {
+	dummy := func(str string) {}
+	for n := 0; n < b.N; n++ {
+		func() {
+			iter := jsoniter.ConfigDefault.BorrowIterator(
+				[]byte(`"hello world!!! hello world!!! hello world!!!"`),
+			)
+			defer jsoniter.ConfigDefault.ReturnIterator(iter)
+			hello := iter.ReadString()
+			dummy(hello)
+		}()
+	}
+}
+
 func readLevel1Hello(iter *jsoniter.Iterator) []Level2 {
 	l2Array := make([]Level2, 0, 2)
 	for iter.ReadArray() {

--- a/pool.go
+++ b/pool.go
@@ -1,7 +1,6 @@
 package jsoniter
 
 import (
-	"github.com/junchih/stringx"
 	"io"
 	"strings"
 )
@@ -50,12 +49,4 @@ func (cfg *frozenConfig) borrowStringBuilder() *strings.Builder {
 func (cfg *frozenConfig) returnStringBuilder(builder *strings.Builder) {
 	builder.Reset()
 	cfg.stringBuilderPool.Put(builder)
-}
-
-func (cfg *frozenConfig) borrowStringFactory() *stringx.Factory {
-	return cfg.stringFactoryPool.Get().(*stringx.Factory)
-}
-
-func (cfg *frozenConfig) returnStringFactory(factory *stringx.Factory) {
-	cfg.stringFactoryPool.Put(factory)
 }

--- a/pool.go
+++ b/pool.go
@@ -1,7 +1,9 @@
 package jsoniter
 
 import (
+	"github.com/junchih/stringx"
 	"io"
+	"strings"
 )
 
 // IteratorPool a thread safe pool of iterators with same configuration
@@ -39,4 +41,21 @@ func (cfg *frozenConfig) ReturnIterator(iter *Iterator) {
 	iter.Error = nil
 	iter.Attachment = nil
 	cfg.iteratorPool.Put(iter)
+}
+
+func (cfg *frozenConfig) borrowStringBuilder() *strings.Builder {
+	return cfg.stringBuilderPool.Get().(*strings.Builder)
+}
+
+func (cfg *frozenConfig) returnStringBuilder(builder *strings.Builder) {
+	builder.Reset()
+	cfg.stringBuilderPool.Put(builder)
+}
+
+func (cfg *frozenConfig) borrowStringFactory() *stringx.Factory {
+	return cfg.stringFactoryPool.Get().(*stringx.Factory)
+}
+
+func (cfg *frozenConfig) returnStringFactory(factory *stringx.Factory) {
+	cfg.stringFactoryPool.Put(factory)
 }


### PR DESCRIPTION
According issue #240 , there is no reason why we don't, so I've tried.

And we are facing the real problems, the `json.Unmarshal` has been in our service's hot path. The `Iterator.ReadString` and `Iterator.readStringSlowPath` has been called multiple times per second. Any reasonable patch which could reduce the memory allocation will be valuable.

I've tried to avoid to use any incompatible trick of Golang. So if there is any plan to support new features of golang v1.10, this PR should be helpful I think.