### PR TITLE
Don't marshal empty byte or uint8 slice as null

### DIFF
--- a/misc_tests/jsoniter_array_test.go
+++ b/misc_tests/jsoniter_array_test.go
@@ -158,6 +158,27 @@ func Test_encode_byte_array(t *testing.T) {
 	should.Equal(`"AQID"`, string(bytes))
 }
 
+func Test_encode_empty_byte_array(t *testing.T) {
+	should := require.New(t)
+	bytes, err := json.Marshal([]byte{})
+	should.Nil(err)
+	should.Equal(`""`, string(bytes))
+	bytes, err = jsoniter.Marshal([]byte{})
+	should.Nil(err)
+	should.Equal(`""`, string(bytes))
+}
+
+func Test_encode_nil_byte_array(t *testing.T) {
+	should := require.New(t)
+	var nilSlice []byte
+	bytes, err := json.Marshal(nilSlice)
+	should.Nil(err)
+	should.Equal(`null`, string(bytes))
+	bytes, err = jsoniter.Marshal(nilSlice)
+	should.Nil(err)
+	should.Equal(`null`, string(bytes))
+}
+
 func Test_decode_byte_array_from_base64(t *testing.T) {
 	should := require.New(t)
 	data := []byte{}

--- a/reflect_native.go
+++ b/reflect_native.go
@@ -432,17 +432,19 @@ func (codec *base64Codec) Decode(ptr unsafe.Pointer, iter *Iterator) {
 }
 
 func (codec *base64Codec) Encode(ptr unsafe.Pointer, stream *Stream) {
-	src := *((*[]byte)(ptr))
-	if len(src) == 0 {
+	if codec.sliceType.UnsafeIsNil(ptr) {
 		stream.WriteNil()
 		return
 	}
+	src := *((*[]byte)(ptr))
 	encoding := base64.StdEncoding
 	stream.writeByte('"')
-	size := encoding.EncodedLen(len(src))
-	buf := make([]byte, size)
-	encoding.Encode(buf, src)
-	stream.buf = append(stream.buf, buf...)
+	if len(src) != 0 {
+		size := encoding.EncodedLen(len(src))
+		buf := make([]byte, size)
+		encoding.Encode(buf, src)
+		stream.buf = append(stream.buf, buf...)
+	}
 	stream.writeByte('"')
 }
 


### PR DESCRIPTION
Fixes https://github.com/json-iterator/go/issues/272

`[]byte` or `[]uint8` are encoded as base-64 encoded strings. So, only nil slices of these types should get marshalled as `null`, and non-nil empty slices should get marshalled as `""`.

This restores compatibility with the standard library.

I verified that this patch works locally. Even though tests for these exist in https://github.com/json-iterator/go/blob/master/type_tests/slice_test.go, I couldn't reproduce a case where the test case was fuzzed to an empty `[]byte` or `[]uint8` slice... :confused:

/cc @taowen @thockin 
fyi @liggitt @dims @neolit123