### PR TITLE
fix #372: add AppendSkip iterator method

### DIFF
--- a/skip_tests/jsoniter_skip_test.go
+++ b/skip_tests/jsoniter_skip_test.go
@@ -105,6 +105,15 @@ func Test_skip_and_return_bytes_with_reader(t *testing.T) {
 	should.Equal(`{"a" : [{"stream": "c"}], "d": 102 }`, string(skipped))
 }
 
+func Test_append_skip_and_return_bytes_with_reader(t *testing.T) {
+	should := require.New(t)
+	iter := jsoniter.Parse(jsoniter.ConfigDefault, bytes.NewBufferString(`[ {"a" : [{"stream": "c"}], "d": 102 }, "stream"]`), 4)
+	iter.ReadArray()
+	buf := make([]byte, 0, 1024)
+	buf = iter.SkipAndAppendBytes(buf)
+	should.Equal(`{"a" : [{"stream": "c"}], "d": 102 }`, string(buf))
+}
+
 func Test_skip_empty(t *testing.T) {
 	should := require.New(t)
 	should.NotNil(jsoniter.Get([]byte("")).LastError())


### PR DESCRIPTION
This PR adds `AppendSkip` method that will allow buffer reuse between skips, as described in #372 


The following part was removed:
```go
	if len(captured) == 0 {
		copied := make([]byte, len(remaining))
		copy(copied, remaining)
		return copied
	}
```
Because it is equivalent to `append(captured, remaining...)`.

Also I've removed the unused `captureBuffer` structure.

Please ping me if you need any adjustments, clarification or additional tests.