### PR TITLE
add WriteBytesAsString()

### DIFF
--- a/extension_tests/decoder_test.go
+++ b/extension_tests/decoder_test.go
@@ -38,7 +38,7 @@ func Test_customize_byte_array_encoder(t *testing.T) {
 	should := require.New(t)
 	jsoniter.RegisterTypeEncoderFunc("[]uint8", func(ptr unsafe.Pointer, stream *jsoniter.Stream) {
 		t := *((*[]byte)(ptr))
-		stream.WriteString(string(t))
+		stream.WriteBytesAsString(t)
 	}, nil)
 	//defer jsoniter.ConfigDefault.(*frozenConfig).cleanEncoders()
 	val := []byte("abc")

--- a/reflect_struct_encoder.go
+++ b/reflect_struct_encoder.go
@@ -202,7 +202,7 @@ func (encoder *stringModeStringEncoder) Encode(ptr unsafe.Pointer, stream *Strea
 	tempStream := encoder.cfg.BorrowStream(nil)
 	defer encoder.cfg.ReturnStream(tempStream)
 	encoder.elemEncoder.Encode(ptr, tempStream)
-	stream.WriteString(string(tempStream.Buffer()))
+	stream.WriteBytesAsString(tempStream.Buffer())
 }
 
 func (encoder *stringModeStringEncoder) IsEmpty(ptr unsafe.Pointer) bool {

--- a/stream_str.go
+++ b/stream_str.go
@@ -2,6 +2,7 @@ package jsoniter
 
 import (
 	"unicode/utf8"
+	"unsafe"
 )
 
 // htmlSafeSet holds the value true if the ASCII character with the given
@@ -305,6 +306,13 @@ func writeStringSlowPathWithHTMLEscaped(stream *Stream, i int, s string, valLen 
 		stream.WriteRaw(s[start:])
 	}
 	stream.writeByte('"')
+}
+
+// WriteBytesAsString writes b to the stream (without html escapes) as if it
+// were a string. (If you start out with a []byte, calling this instead of
+// WriteString avoids an allocation.)
+func (stream *Stream) WriteBytesAsString(b []byte) {
+	stream.WriteString(*(*string)(unsafe.Pointer(&b)))
 }
 
 // WriteString write string to stream without html escape


### PR DESCRIPTION
I have a situation where I'm constructing key names, and I want to avoid an allocation; I can do this cast in my code, but I thought I'd see if there's interest in accepting this so it's obvious for other people how to do this?