### PR TITLE
Permit zero alloc reads

### DIFF
--- a/benchmarks/jsoniter_large_file_test.go
+++ b/benchmarks/jsoniter_large_file_test.go
@@ -216,7 +216,7 @@ func scanBytes(iter *jsoniter.Iterator, buf []byte) []byte {
 	return buf
 }
 
-func Benchmark_scan_string(b *testing.B) {
+func Benchmark_custom_scan(b *testing.B) {
 	file, _ := os.Open("/tmp/large-file.json")
 	fb, _ := ioutil.ReadAll(file)
 	file.Close()

--- a/benchmarks/jsoniter_large_file_test.go
+++ b/benchmarks/jsoniter_large_file_test.go
@@ -1,11 +1,13 @@
 package test
 
 import (
+	"bytes"
 	"encoding/json"
-	"github.com/json-iterator/go"
 	"io/ioutil"
 	"os"
 	"testing"
+
+	jsoniter "github.com/json-iterator/go"
 )
 
 //func Test_large_file(t *testing.T) {
@@ -155,4 +157,87 @@ func Benchmark_json_large_file(b *testing.B) {
 			b.Error(err)
 		}
 	}
+}
+
+func scan(iter *jsoniter.Iterator) {
+	next := iter.WhatIsNext()
+	switch next {
+	case jsoniter.InvalidValue:
+		iter.Skip()
+	case jsoniter.StringValue:
+		iter.Skip()
+	case jsoniter.NumberValue:
+		iter.Skip()
+	case jsoniter.NilValue:
+		iter.Skip()
+	case jsoniter.BoolValue:
+		iter.Skip()
+	case jsoniter.ArrayValue:
+		iter.ReadArrayCB(func(iter *jsoniter.Iterator) bool {
+			scan(iter)
+			return true
+		})
+	case jsoniter.ObjectValue:
+		iter.ReadMapCB(func(iter *jsoniter.Iterator, key string) bool {
+			scan(iter)
+			return true
+		})
+	default:
+		iter.Skip()
+	}
+}
+
+func scanBytes(iter *jsoniter.Iterator, buf []byte) []byte {
+	next := iter.WhatIsNext()
+	switch next {
+	case jsoniter.InvalidValue:
+		iter.Skip()
+	case jsoniter.StringValue:
+		iter.Skip()
+	case jsoniter.NumberValue:
+		iter.Skip()
+	case jsoniter.NilValue:
+		iter.Skip()
+	case jsoniter.BoolValue:
+		iter.Skip()
+	case jsoniter.ArrayValue:
+		iter.ReadArrayCB(func(iter *jsoniter.Iterator) bool {
+			buf = scanBytes(iter, buf)
+			return true
+		})
+	case jsoniter.ObjectValue:
+		iter.ReadMapCBFieldAsBytes(buf, func(iter *jsoniter.Iterator, field []byte) bool {
+			buf = scanBytes(iter, field)
+			return true
+		})
+	default:
+		iter.Skip()
+	}
+	return buf
+}
+
+func Benchmark_scan_string(b *testing.B) {
+	file, _ := os.Open("/tmp/large-file.json")
+	fb, _ := ioutil.ReadAll(file)
+	file.Close()
+
+	// Benchmark_scan_string/string-12                           100000             15429 ns/op            4952 B/op         76 allocs/op
+	// Benchmark_scan_string/bytes-12                            100000             12741 ns/op            4312 B/op          6 allocs/op
+
+	b.Run("string", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ResetTimer()
+		for n := 0; n < b.N; n++ {
+			iter := jsoniter.Parse(jsoniter.ConfigDefault, bytes.NewReader(fb), 4096)
+			scan(iter)
+		}
+	})
+	b.Run("bytes", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ResetTimer()
+		for n := 0; n < b.N; n++ {
+			iter := jsoniter.Parse(jsoniter.ConfigDefault, bytes.NewReader(fb), 4096)
+			scanBytes(iter, nil)
+		}
+	})
 }

--- a/iter_skip_strict.go
+++ b/iter_skip_strict.go
@@ -84,7 +84,7 @@ func (iter *Iterator) trySkipString() bool {
 
 func (iter *Iterator) skipObject() {
 	iter.unreadByte()
-	iter.ReadObjectCB(func(iter *Iterator, field string) bool {
+	iter.ReadMapCBFieldAsBytes(nil, func(iter *Iterator, field []byte) bool {
 		iter.Skip()
 		return true
 	})

--- a/justkey_test.go
+++ b/justkey_test.go
@@ -1,0 +1,103 @@
+package jsoniter_test
+
+import (
+	"strings"
+
+	jsoniter "github.com/json-iterator/go"
+
+	"testing"
+)
+
+type keycollector []byte
+
+func (kc *keycollector) readKeysString(iter *jsoniter.Iterator) {
+	next := iter.WhatIsNext()
+	switch next {
+	case jsoniter.InvalidValue:
+		iter.Skip()
+	case jsoniter.StringValue:
+		iter.Skip()
+	case jsoniter.NumberValue:
+		iter.Skip()
+	case jsoniter.NilValue:
+		iter.Skip()
+	case jsoniter.BoolValue:
+		iter.Skip()
+	case jsoniter.ArrayValue:
+		iter.ReadArrayCB(func(iter *jsoniter.Iterator) bool {
+			kc.readKeysString(iter)
+			return true
+		})
+	case jsoniter.ObjectValue:
+		iter.ReadMapCB(func(iter *jsoniter.Iterator, key string) bool {
+			*kc = append(*kc, []byte(key)...)
+			kc.readKeysString(iter)
+			return true
+		})
+	default:
+		iter.Skip()
+	}
+}
+
+func (kc *keycollector) readKeysBytes(iter *jsoniter.Iterator, buf []byte) []byte {
+	next := iter.WhatIsNext()
+	switch next {
+	case jsoniter.InvalidValue:
+		iter.Skip()
+	case jsoniter.StringValue:
+		iter.Skip()
+	case jsoniter.NumberValue:
+		iter.Skip()
+	case jsoniter.NilValue:
+		iter.Skip()
+	case jsoniter.BoolValue:
+		iter.Skip()
+	case jsoniter.ArrayValue:
+		iter.ReadArrayCB(func(iter *jsoniter.Iterator) bool {
+			buf = kc.readKeysBytes(iter, buf)
+			return true
+		})
+	case jsoniter.ObjectValue:
+		iter.ReadMapCBFieldAsBytes(buf, func(iter *jsoniter.Iterator, key []byte) bool {
+			*kc = append(*kc, key...)
+			buf = kc.readKeysBytes(iter, key)
+			return true
+		})
+	default:
+		iter.Skip()
+	}
+	return buf
+}
+
+func TestReadKeys(t *testing.T) {
+	str := `{
+    "gravatar": {
+      "handle": "buger",
+      "urls": [
+      ],
+      "avatar": "http://1.gravatar.com/avatar/f7c8edd577d13b8930d5522f28123510",
+      "avatars": [
+        {
+          "url": "http://1.gravatar.com/avatar/f7c8edd577d13b8930d5522f28123510",
+          "type": "thumbnail"
+        }
+      ]
+    }`
+
+	want := "gravatarhandleurlsavataravatarsurltype"
+
+	var keysString keycollector
+	keysString.readKeysString(jsoniter.Parse(jsoniter.ConfigDefault, strings.NewReader(str), 4096))
+	got := string(keysString)
+	if got != want {
+		t.Errorf("wanted %v, got %v", want, got)
+	}
+
+	var keysBytes keycollector
+	keysBytes.readKeysBytes(jsoniter.Parse(jsoniter.ConfigDefault, strings.NewReader(str), 4096), nil)
+	got = string(keysBytes)
+	if got != want {
+		t.Errorf("wanted %v, got %v", want, got)
+	}
+
+}

--- a/reflect_map.go
+++ b/reflect_map.go
@@ -156,7 +156,7 @@ func (decoder *mapDecoder) Decode(ptr unsafe.Pointer, iter *Iterator) {
 		mapType.UnsafeSet(ptr, mapType.UnsafeMakeMap(0))
 	}
 	if c != '{' {
-		iter.ReportError("ReadMapCB", `expect { or n, but found `+string([]byte{c}))
+		iter.ReportError("Decode", `expect { or n, but found `+string([]byte{c}))
 		return
 	}
 	c = iter.nextToken()
@@ -164,7 +164,7 @@ func (decoder *mapDecoder) Decode(ptr unsafe.Pointer, iter *Iterator) {
 		return
 	}
 	if c != '"' {
-		iter.ReportError("ReadMapCB", `expect " after }, but found `+string([]byte{c}))
+		iter.ReportError("Decode", `expect " after }, but found `+string([]byte{c}))
 		return
 	}
 	iter.unreadByte()
@@ -172,7 +172,7 @@ func (decoder *mapDecoder) Decode(ptr unsafe.Pointer, iter *Iterator) {
 	decoder.keyDecoder.Decode(key, iter)
 	c = iter.nextToken()
 	if c != ':' {
-		iter.ReportError("ReadMapCB", "expect : after object field, but found "+string([]byte{c}))
+		iter.ReportError("Decode", "expect : after object field, but found "+string([]byte{c}))
 		return
 	}
 	elem := decoder.elemType.UnsafeNew()
@@ -183,7 +183,7 @@ func (decoder *mapDecoder) Decode(ptr unsafe.Pointer, iter *Iterator) {
 		decoder.keyDecoder.Decode(key, iter)
 		c = iter.nextToken()
 		if c != ':' {
-			iter.ReportError("ReadMapCB", "expect : after object field, but found "+string([]byte{c}))
+			iter.ReportError("Decode", "expect : after object field, but found "+string([]byte{c}))
 			return
 		}
 		elem := decoder.elemType.UnsafeNew()
@@ -191,7 +191,7 @@ func (decoder *mapDecoder) Decode(ptr unsafe.Pointer, iter *Iterator) {
 		decoder.mapType.UnsafeSetIndex(ptr, key, elem)
 	}
 	if c != '}' {
-		iter.ReportError("ReadMapCB", `expect }, but found `+string([]byte{c}))
+		iter.ReportError("Decode", `expect }, but found `+string([]byte{c}))
 	}
 }
 
@@ -202,13 +202,13 @@ type numericMapKeyDecoder struct {
 func (decoder *numericMapKeyDecoder) Decode(ptr unsafe.Pointer, iter *Iterator) {
 	c := iter.nextToken()
 	if c != '"' {
-		iter.ReportError("ReadMapCB", `expect ", but found `+string([]byte{c}))
+		iter.ReportError("Decode", `expect ", but found `+string([]byte{c}))
 		return
 	}
 	decoder.decoder.Decode(ptr, iter)
 	c = iter.nextToken()
 	if c != '"' {
-		iter.ReportError("ReadMapCB", `expect ", but found `+string([]byte{c}))
+		iter.ReportError("Decode", `expect ", but found `+string([]byte{c}))
 		return
 	}
 }

--- a/skip_tests/jsoniter_skip_test.go
+++ b/skip_tests/jsoniter_skip_test.go
@@ -148,6 +148,7 @@ func Benchmark_jsoniter_skip(b *testing.B) {
     },
     "code": 200
 }`)
+	b.ReportAllocs()
 	for n := 0; n < b.N; n++ {
 		result := TestResp{}
 		iter := jsoniter.ParseBytes(jsoniter.ConfigDefault, input)


### PR DESCRIPTION
It's not currently possible to use jsoniter without having it allocate for each field name. This makes it possible. I found a couple existing functions that can benefit from this change, so it's overall a slight performance improvement.

```
benchmark                                         old ns/op     new ns/op     delta
Benchmark_encode_string_with_SetEscapeHTML-12     1373          1296          -5.61%
Benchmark_jsoniter_large_file-12                  25578         24599         -3.83%
Benchmark_json_large_file-12                      54500         54448         -0.10%
Benchmark_jsoniter_array-12                       161           162           +0.62%
Benchmark_json_array-12                           1722          1666          -3.25%
Benchmark_jsoniter_float-12                       27.8          26.1          -6.12%
Benchmark_json_float-12                           526           541           +2.85%
Benchmark_jsoniter_encode_int-12                  17.3          17.1          -1.16%
Benchmark_itoa-12                                 71.6          71.2          -0.56%
Benchmark_jsoniter_int-12                         20.8          22.0          +5.77%
Benchmark_json_int-12                             521           514           -1.34%
Benchmark_jsoniter_nested-12                      793           760           -4.16%
Benchmark_json_nested-12                          3032          2908          -4.09%
Benchmark_jsoniter_skip-12                        2075          2126          +2.46%
Benchmark_json_skip-12                            7361          7357          -0.05%

benchmark                                         old allocs     new allocs     delta
Benchmark_encode_string_with_SetEscapeHTML-12     6              6              +0.00%
Benchmark_jsoniter_large_file-12                  79             27             -65.82%
Benchmark_json_large_file-12                      14             14             +0.00%
Benchmark_jsoniter_array-12                       0              0              +0.00%
Benchmark_jsoniter_float-12                       0              0              +0.00%

benchmark                                         old bytes     new bytes     delta
Benchmark_encode_string_with_SetEscapeHTML-12     760           760           +0.00%
Benchmark_jsoniter_large_file-12                  4904          4576          -6.69%
Benchmark_json_large_file-12                      6632          6632          +0.00%
Benchmark_jsoniter_array-12                       0             0             +0.00%
Benchmark_jsoniter_float-12                       0             0             +0.00%
```


I added this benchmark to show the difference more clearly:

```
Benchmark_custom_scan/string-12                           100000             15149 ns/op            4816 B/op         76 allocs/op
Benchmark_custom_scan/bytes-12                            100000             12843 ns/op            4312 B/op          6 allocs/op
```

Often, users will store the field names and need to do this allocation anyway. But not always.