### PR TITLE
Fixes #405 - Encode nil map into null

### DIFF
--- a/misc_tests/jsoniter_map_test.go
+++ b/misc_tests/jsoniter_map_test.go
@@ -42,3 +42,11 @@ func Test_map_eface_of_eface(t *testing.T) {
 	should.NoError(err)
 	should.Equal(`{"1":2,"3":"4"}`, output)
 }
+
+func Test_encode_nil_map(t *testing.T) {
+	should := require.New(t)
+	var nilMap map[string]string
+	output, err := jsoniter.MarshalToString(nilMap)
+	should.NoError(err)
+	should.Equal(`null`, output)
+}

--- a/reflect_map.go
+++ b/reflect_map.go
@@ -249,6 +249,10 @@ type mapEncoder struct {
 }
 
 func (encoder *mapEncoder) Encode(ptr unsafe.Pointer, stream *Stream) {
+	if *(*unsafe.Pointer)(ptr) == nil {
+		stream.WriteNil()
+		return
+	}
 	stream.WriteObjectStart()
 	iter := encoder.mapType.UnsafeIterate(ptr)
 	for i := 0; iter.HasNext(); i++ {


### PR DESCRIPTION
Fixes #405 

- Add test to encode nil map and check for `null`
- Fix nil map being encoded as `{}`