### PR TITLE
Ignore unnamed literals in structs

### DIFF
--- a/reflect_extension.go
+++ b/reflect_extension.go
@@ -341,7 +341,7 @@ func describeStruct(ctx *ctx, typ reflect2.Type) *StructDescriptor {
 		if ctx.onlyTaggedField && !hastag && !field.Anonymous() {
 			continue
 		}
-		if tag == "-" {
+		if tag == "-" || field.Name() == "_" {
 			continue
 		}
 		tagParts := strings.Split(tag, ",")

--- a/type_tests/struct_embedded_test.go
+++ b/type_tests/struct_embedded_test.go
@@ -60,6 +60,7 @@ func init() {
 		(*SameLevel2NoTags)(nil),
 		(*SameLevel2Tagged)(nil),
 		(*EmbeddedPtr)(nil),
+		(*UnnamedLiteral)(nil),
 	)
 }
 
@@ -230,4 +231,8 @@ type EmbeddedPtrOption struct {
 
 type EmbeddedPtr struct {
 	EmbeddedPtrOption `json:","`
+}
+
+type UnnamedLiteral struct {
+	_ struct{}
 }


### PR DESCRIPTION
solves: https://github.com/json-iterator/go/issues/415 
demo of bug: https://play.golang.org/p/QbqGl3ztXGs