### PR TITLE
Add MaxDepth as a config option

### DIFF
--- a/api_tests/config_test.go
+++ b/api_tests/config_test.go
@@ -43,19 +43,12 @@ func Test_max_depth(t *testing.T) {
 		{jsonDepth: 5, cfgMaxDepth: 6},
 		{jsonDepth: 5, cfgMaxDepth: 5},
 		{jsonDepth: 5, cfgMaxDepth: 4, expectedErr: "max depth"},
-		// Now try some larger values to figure out the limit
+		// Try a large depth without a limit
 		{jsonDepth: 128000, cfgMaxDepth: -1},
-		{jsonDepth: 512000, cfgMaxDepth: -1},
-		{jsonDepth: 768000, cfgMaxDepth: -1},
-		{jsonDepth: 860367, cfgMaxDepth: -1}, // largest value for jsoniter without stack overflow
 	}
 
 	for _, test := range tests {
 		t.Run(fmt.Sprintf("jsonDepth:%v_cfgMaxDepth:%v", test.jsonDepth, test.cfgMaxDepth), func(t *testing.T) {
-			if testing.Short() && test.jsonDepth >= 512000 {
-				t.Skip("skipping in -short due to large input data")
-			}
-
 			should := require.New(t)
 			cfg := jsoniter.Config{MaxDepth: test.cfgMaxDepth}.Froze()
 

--- a/api_tests/config_test.go
+++ b/api_tests/config_test.go
@@ -2,9 +2,11 @@ package test
 
 import (
 	"encoding/json"
+	"fmt"
+	"strings"
 	"testing"
 
-	"github.com/json-iterator/go"
+	jsoniter "github.com/json-iterator/go"
 	"github.com/stretchr/testify/require"
 )
 
@@ -22,6 +24,51 @@ func Test_customize_float_marshal(t *testing.T) {
 	str, err := json.MarshalToString(float32(1.23456789))
 	should.Nil(err)
 	should.Equal("1.234568", str)
+}
+
+func Test_max_depth(t *testing.T) {
+	deepJSON := func(depth int) []byte {
+		return []byte(strings.Repeat(`[`, depth) + strings.Repeat(`]`, depth))
+	}
+
+	tests := []struct {
+		jsonDepth   int
+		cfgMaxDepth int
+		expectedErr string
+	}{
+		// Test the default depth
+		{jsonDepth: 10000, cfgMaxDepth: 0},
+		{jsonDepth: 10001, cfgMaxDepth: 0, expectedErr: "max depth"},
+		// Test max depth logic
+		{jsonDepth: 5, cfgMaxDepth: 6},
+		{jsonDepth: 5, cfgMaxDepth: 5},
+		{jsonDepth: 5, cfgMaxDepth: 4, expectedErr: "max depth"},
+		// Now try some larger values to figure out the limit
+		{jsonDepth: 128000, cfgMaxDepth: -1},
+		{jsonDepth: 512000, cfgMaxDepth: -1},
+		{jsonDepth: 768000, cfgMaxDepth: -1},
+		{jsonDepth: 860367, cfgMaxDepth: -1}, // largest value for jsoniter without stack overflow
+	}
+
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("jsonDepth:%v_cfgMaxDepth:%v", test.jsonDepth, test.cfgMaxDepth), func(t *testing.T) {
+			if testing.Short() && test.jsonDepth >= 512000 {
+				t.Skip("skipping in -short due to large input data")
+			}
+
+			should := require.New(t)
+			cfg := jsoniter.Config{MaxDepth: test.cfgMaxDepth}.Froze()
+
+			var val interface{}
+			err := cfg.Unmarshal(deepJSON(test.jsonDepth), &val)
+			if test.expectedErr != "" {
+				should.Error(err)
+				should.Contains(err.Error(), test.expectedErr)
+			} else {
+				should.NoError(err)
+			}
+		})
+	}
 }
 
 func Test_customize_tag_key(t *testing.T) {

--- a/iter.go
+++ b/iter.go
@@ -327,12 +327,9 @@ func (iter *Iterator) Read() interface{} {
 	}
 }
 
-// limit maximum depth of nesting, as allowed by https://tools.ietf.org/html/rfc7159#section-9
-const maxDepth = 10000
-
 func (iter *Iterator) incrementDepth() (success bool) {
 	iter.depth++
-	if iter.depth <= maxDepth {
+	if iter.depth <= iter.cfg.maxDepth || iter.cfg.maxDepth < 0 {
 		return true
 	}
 	iter.ReportError("incrementDepth", "exceeded max depth")


### PR DESCRIPTION
Default `MaxDepth` is 10,000 to match the existing `maxDepth` constant added in #410

`ConfigCompatibleWithStandardLibrary` retains unlimited depth (via `-1`), until https://github.com/golang/go/issues/31789 has been decided (it got dropped from the 1.14 milestone)