### PR TITLE
pass nested error in compatible configuration, fixes #388

### DIFF
--- a/reflect_map.go
+++ b/reflect_map.go
@@ -320,6 +320,9 @@ func (encoder *sortKeysMapEncoder) Encode(ptr unsafe.Pointer, stream *Stream) {
 		}
 		stream.Write(keyValue.keyValue)
 	}
+	if subStream.Error != nil && stream.Error == nil {
+		stream.Error = subStream.Error
+	}
 	stream.WriteObjectEnd()
 	stream.cfg.ReturnStream(subStream)
 	stream.cfg.ReturnIterator(subIter)

--- a/value_tests/invalid_test.go
+++ b/value_tests/invalid_test.go
@@ -103,18 +103,44 @@ func Test_invalid_float(t *testing.T) {
 }
 
 func Test_chan(t *testing.T) {
-	t.Skip("do not support chan")
-
 	type TestObject struct {
 		MyChan  chan bool
 		MyField int
 	}
 
-	should := require.New(t)
 	obj := TestObject{}
-	str, err := json.Marshal(obj)
-	should.Nil(err)
-	should.Equal(``, str)
+
+	t.Run("Encode channel", func(t *testing.T) {
+		should := require.New(t)
+		str, err := jsoniter.Marshal(obj)
+		should.NotNil(err)
+		should.Nil(str)
+	})
+
+	t.Run("Encode channel using compatible configuration", func(t *testing.T) {
+		should := require.New(t)
+		str, err := jsoniter.ConfigCompatibleWithStandardLibrary.Marshal(obj)
+		should.NotNil(err)
+		should.Nil(str)
+	})
+}
+
+func Test_invalid_in_map(t *testing.T) {
+	testMap := map[string]interface{}{"chan": make(chan interface{})}
+
+	t.Run("Encode map with invalid content", func(t *testing.T) {
+		should := require.New(t)
+		str, err := jsoniter.Marshal(testMap)
+		should.NotNil(err)
+		should.Nil(str)
+	})
+
+	t.Run("Encode map with invalid content using compatible configuration", func(t *testing.T) {
+		should := require.New(t)
+		str, err := jsoniter.ConfigCompatibleWithStandardLibrary.Marshal(testMap)
+		should.NotNil(err)
+		should.Nil(str)
+	})
 }
 
 func Test_invalid_number(t *testing.T) {


### PR DESCRIPTION
When invalid types inside a map were marshalled (in general, as soon as
sorted maps have been configured), the error message has not been
propagated out of the map's `subStream`.

Also fix and re-enable the channel test, which now resembles the
behavior of `encoding/json` and tests both default and compatible
configurations.

Signed-off-by: Jens Erat <email@jenserat.de>