### PR TITLE
fix nil attachment on stream in custom encoder on sorted map

### DIFF
--- a/reflect_map.go
+++ b/reflect_map.go
@@ -290,6 +290,7 @@ func (encoder *sortKeysMapEncoder) Encode(ptr unsafe.Pointer, stream *Stream) {
 	stream.WriteObjectStart()
 	mapIter := encoder.mapType.UnsafeIterate(ptr)
 	subStream := stream.cfg.BorrowStream(nil)
+	subStream.Attachment = stream.Attachment
 	subIter := stream.cfg.BorrowIterator(nil)
 	keyValues := encodedKeyValues{}
 	for mapIter.HasNext() {

--- a/reflect_struct_encoder.go
+++ b/reflect_struct_encoder.go
@@ -200,6 +200,7 @@ type stringModeStringEncoder struct {
 
 func (encoder *stringModeStringEncoder) Encode(ptr unsafe.Pointer, stream *Stream) {
 	tempStream := encoder.cfg.BorrowStream(nil)
+	tempStream.Attachment = stream.Attachment
 	defer encoder.cfg.ReturnStream(tempStream)
 	encoder.elemEncoder.Encode(ptr, tempStream)
 	stream.WriteString(string(tempStream.Buffer()))


### PR DESCRIPTION
Hello, thank you for a library !

This pr fixes next problem:
1. We create jsoniter.Stream with SortMapKeys enable
2. Pass attachment to created stream
3. Try to serialize map with custom types
4. Attachment will be null on stream in Encode method

Example in test - *Test_custom_encoder_attachment*
