### PR TITLE
fix issue #389 #411

### DIFF
--- a/config.go
+++ b/config.go
@@ -183,11 +183,11 @@ func (cfg *frozenConfig) validateJsonRawMessage(extension EncoderExtension) {
 	encoder := &funcEncoder{func(ptr unsafe.Pointer, stream *Stream) {
 		rawMessage := *(*json.RawMessage)(ptr)
 		iter := cfg.BorrowIterator([]byte(rawMessage))
+		defer cfg.ReturnIterator(iter)
 		iter.Read()
-		if iter.Error != nil {
+		if iter.Error != nil && iter.Error != io.EOF {
 			stream.WriteRaw("null")
 		} else {
-			cfg.ReturnIterator(iter)
 			stream.WriteRaw(string(rawMessage))
 		}
 	}, func(ptr unsafe.Pointer) bool {

--- a/value_tests/raw_message_test.go
+++ b/value_tests/raw_message_test.go
@@ -7,6 +7,9 @@ import (
 func init() {
 	marshalCases = append(marshalCases,
 		json.RawMessage("{}"),
+		json.RawMessage("12345"),
+		json.RawMessage("3.14"),
+		json.RawMessage("-0.5e10"),
 		struct {
 			Env   string          `json:"env"`
 			Extra json.RawMessage `json:"extra,omitempty"`


### PR DESCRIPTION
If the input json is integer/float, ```iter.Read()``` will meet EOF, which will make ```iter.Error``` not nil. But it's actually not an error.