### PR TITLE
fix issue #421

### DIFF
--- a/misc_tests/jsoniter_object_test.go
+++ b/misc_tests/jsoniter_object_test.go
@@ -2,6 +2,7 @@ package misc_tests
 
 import (
 	"bytes"
+	"reflect"
 	"testing"
 
 	"github.com/json-iterator/go"
@@ -146,4 +147,27 @@ func Test_unmarshal_into_existing_value(t *testing.T) {
 	should.Equal(map[string]interface{}{
 		"k": "v",
 	}, m)
+}
+
+// for issue421
+func Test_unmarshal_anonymous_struct_invalid(t *testing.T) {
+	should := require.New(t)
+	t1 := struct {
+		Field1 string
+	}{}
+
+	cfg := jsoniter.ConfigCompatibleWithStandardLibrary
+	err := cfg.UnmarshalFromString(`{"Field1":`, &t1)
+	should.NotNil(err)
+	should.NotContains(err.Error(), reflect.TypeOf(t1).String())
+
+	type TestObject struct {
+		Field1 struct {
+			InnerField1 string
+		}
+	}
+	t2 := TestObject{}
+	err = cfg.UnmarshalFromString(`{"Field1":{"InnerField1"`, &t2)
+	should.NotNil(err)
+	should.NotContains(err.Error(), reflect.TypeOf(t2.Field1).String())
 }

--- a/misc_tests/jsoniter_object_test.go
+++ b/misc_tests/jsoniter_object_test.go
@@ -152,22 +152,221 @@ func Test_unmarshal_into_existing_value(t *testing.T) {
 // for issue421
 func Test_unmarshal_anonymous_struct_invalid(t *testing.T) {
 	should := require.New(t)
-	t1 := struct {
+	t0 := struct {
 		Field1 string
 	}{}
 
 	cfg := jsoniter.ConfigCompatibleWithStandardLibrary
-	err := cfg.UnmarshalFromString(`{"Field1":`, &t1)
+	err := cfg.UnmarshalFromString(`{"Field1":`, &t0)
 	should.NotNil(err)
-	should.NotContains(err.Error(), reflect.TypeOf(t1).String())
+	should.NotContains(err.Error(), reflect.TypeOf(t0).String())
 
-	type TestObject struct {
+	cfgCaseSensitive := jsoniter.Config{
+		CaseSensitive: true,
+	}.Froze()
+
+	type TestObject1 struct {
 		Field1 struct {
 			InnerField1 string
 		}
 	}
-	t2 := TestObject{}
-	err = cfg.UnmarshalFromString(`{"Field1":{"InnerField1"`, &t2)
+	t1 := TestObject1{}
+	err = cfgCaseSensitive.UnmarshalFromString(`{"Field1":{"InnerField1"`, &t1)
 	should.NotNil(err)
-	should.NotContains(err.Error(), reflect.TypeOf(t2.Field1).String())
+	should.NotContains(err.Error(), reflect.TypeOf(t1.Field1).String())
+	should.Contains(err.Error(), reflect.TypeOf(t1).String())
+
+	type TestObject2 struct {
+		Field1 int
+		Field2 struct {
+			InnerField1 string
+			InnerField2 string
+		}
+	}
+	t2 := TestObject2{}
+	err = cfgCaseSensitive.UnmarshalFromString(`{"Field2":{"InnerField2"`, &t2)
+	should.NotNil(err)
+	should.NotContains(err.Error(), reflect.TypeOf(t2.Field2).String())
+	should.Contains(err.Error(), reflect.TypeOf(t2).String())
+
+	type TestObject3 struct {
+		Field1 int
+		Field2 int
+		Field3 struct {
+			InnerField1 string
+			InnerField2 string
+			InnerField3 string
+		}
+	}
+	t3 := TestObject3{}
+	err = cfgCaseSensitive.UnmarshalFromString(`{"Field3":{"InnerField3"`, &t3)
+	should.NotNil(err)
+	should.NotContains(err.Error(), reflect.TypeOf(t3.Field3).String())
+	should.Contains(err.Error(), reflect.TypeOf(t3).String())
+
+	type TestObject4 struct {
+		Field1 int
+		Field2 int
+		Field3 int
+		Field4 struct {
+			InnerField1 string
+			InnerField2 string
+			InnerField3 string
+			InnerField4 string
+		}
+	}
+	t4 := TestObject4{}
+	err = cfgCaseSensitive.UnmarshalFromString(`{"Field4":{"InnerField4"`, &t4)
+	should.NotNil(err)
+	should.NotContains(err.Error(), reflect.TypeOf(t4.Field4).String())
+	should.Contains(err.Error(), reflect.TypeOf(t4).String())
+
+	type TestObject5 struct {
+		Field1 int
+		Field2 int
+		Field3 int
+		Field4 int
+		Field5 struct {
+			InnerField1 string
+			InnerField2 string
+			InnerField3 string
+			InnerField4 string
+			InnerField5 string
+		}
+	}
+	t5 := TestObject5{}
+	err = cfgCaseSensitive.UnmarshalFromString(`{"Field5":{"InnerField5"`, &t5)
+	should.NotNil(err)
+	should.NotContains(err.Error(), reflect.TypeOf(t5.Field5).String())
+	should.Contains(err.Error(), reflect.TypeOf(t5).String())
+
+	type TestObject6 struct {
+		Field1 int
+		Field2 int
+		Field3 int
+		Field4 int
+		Field5 int
+		Field6 struct {
+			InnerField1 string
+			InnerField2 string
+			InnerField3 string
+			InnerField4 string
+			InnerField5 string
+			InnerField6 string
+		}
+	}
+	t6 := TestObject6{}
+	err = cfgCaseSensitive.UnmarshalFromString(`{"Field6":{"InnerField6"`, &t6)
+	should.NotNil(err)
+	should.NotContains(err.Error(), reflect.TypeOf(t6.Field6).String())
+	should.Contains(err.Error(), reflect.TypeOf(t6).String())
+
+	type TestObject7 struct {
+		Field1 int
+		Field2 int
+		Field3 int
+		Field4 int
+		Field5 int
+		Field6 int
+		Field7 struct {
+			InnerField1 string
+			InnerField2 string
+			InnerField3 string
+			InnerField4 string
+			InnerField5 string
+			InnerField6 string
+			InnerField7 string
+		}
+	}
+	t7 := TestObject7{}
+	err = cfgCaseSensitive.UnmarshalFromString(`{"Field7":{"InnerField7"`, &t7)
+	should.NotNil(err)
+	should.NotContains(err.Error(), reflect.TypeOf(t7.Field7).String())
+	should.Contains(err.Error(), reflect.TypeOf(t7).String())
+
+	type TestObject8 struct {
+		Field1 int
+		Field2 int
+		Field3 int
+		Field4 int
+		Field5 int
+		Field6 int
+		Field7 int
+		Field8 struct {
+			InnerField1 string
+			InnerField2 string
+			InnerField3 string
+			InnerField4 string
+			InnerField5 string
+			InnerField6 string
+			InnerField7 string
+			InnerField8 string
+		}
+	}
+	t8 := TestObject8{}
+	err = cfgCaseSensitive.UnmarshalFromString(`{"Field8":{"InnerField8"`, &t8)
+	should.NotNil(err)
+	should.NotContains(err.Error(), reflect.TypeOf(t8.Field8).String())
+	should.Contains(err.Error(), reflect.TypeOf(t8).String())
+
+	type TestObject9 struct {
+		Field1 int
+		Field2 int
+		Field3 int
+		Field4 int
+		Field5 int
+		Field6 int
+		Field7 int
+		Field8 int
+		Field9 struct {
+			InnerField1 string
+			InnerField2 string
+			InnerField3 string
+			InnerField4 string
+			InnerField5 string
+			InnerField6 string
+			InnerField7 string
+			InnerField8 string
+			InnerField9 string
+		}
+	}
+	t9 := TestObject9{}
+	err = cfgCaseSensitive.UnmarshalFromString(`{"Field9":{"InnerField9"`, &t9)
+	should.NotNil(err)
+	should.NotContains(err.Error(), reflect.TypeOf(t9.Field9).String())
+	should.Contains(err.Error(), reflect.TypeOf(t9).String())
+
+	type TestObject10 struct {
+		Field1  int
+		Field2  int
+		Field3  int
+		Field4  int
+		Field5  int
+		Field6  int
+		Field7  int
+		Field8  int
+		Field9  int
+		Field10 struct {
+			InnerField1  string
+			InnerField2  string
+			InnerField3  string
+			InnerField4  string
+			InnerField5  string
+			InnerField6  string
+			InnerField7  string
+			InnerField8  string
+			InnerField9  string
+			InnerField10 string
+		}
+	}
+	t10 := TestObject10{}
+	err = cfgCaseSensitive.UnmarshalFromString(`{"Field10":{"InnerField10"`, &t10)
+	should.NotNil(err)
+	should.NotContains(err.Error(), reflect.TypeOf(t10.Field10).String())
+	should.Contains(err.Error(), reflect.TypeOf(t10).String())
+
+	err = cfg.UnmarshalFromString(`{"Field10":{"InnerField10"`, &t10)
+	should.NotNil(err)
+	should.NotContains(err.Error(), reflect.TypeOf(t10.Field10).String())
+	should.Contains(err.Error(), reflect.TypeOf(t10).String())
 }

--- a/reflect_struct_decoder.go
+++ b/reflect_struct_decoder.go
@@ -507,7 +507,7 @@ func (decoder *generalStructDecoder) Decode(ptr unsafe.Pointer, iter *Iterator) 
 	for c = ','; c == ','; c = iter.nextToken() {
 		decoder.decodeOneField(ptr, iter)
 	}
-	if iter.Error != nil && iter.Error != io.EOF {
+	if iter.Error != nil && iter.Error != io.EOF && len(decoder.typ.Type1().Name()) != 0 {
 		iter.Error = fmt.Errorf("%v.%s", decoder.typ, iter.Error.Error())
 	}
 	if c != '}' {
@@ -588,7 +588,7 @@ func (decoder *oneFieldStructDecoder) Decode(ptr unsafe.Pointer, iter *Iterator)
 			break
 		}
 	}
-	if iter.Error != nil && iter.Error != io.EOF {
+	if iter.Error != nil && iter.Error != io.EOF && len(decoder.typ.Type1().Name()) != 0 {
 		iter.Error = fmt.Errorf("%v.%s", decoder.typ, iter.Error.Error())
 	}
 	iter.decrementDepth()
@@ -622,7 +622,7 @@ func (decoder *twoFieldsStructDecoder) Decode(ptr unsafe.Pointer, iter *Iterator
 			break
 		}
 	}
-	if iter.Error != nil && iter.Error != io.EOF {
+	if iter.Error != nil && iter.Error != io.EOF && len(decoder.typ.Type1().Name()) != 0 {
 		iter.Error = fmt.Errorf("%v.%s", decoder.typ, iter.Error.Error())
 	}
 	iter.decrementDepth()
@@ -660,7 +660,7 @@ func (decoder *threeFieldsStructDecoder) Decode(ptr unsafe.Pointer, iter *Iterat
 			break
 		}
 	}
-	if iter.Error != nil && iter.Error != io.EOF {
+	if iter.Error != nil && iter.Error != io.EOF && len(decoder.typ.Type1().Name()) != 0 {
 		iter.Error = fmt.Errorf("%v.%s", decoder.typ, iter.Error.Error())
 	}
 	iter.decrementDepth()
@@ -702,7 +702,7 @@ func (decoder *fourFieldsStructDecoder) Decode(ptr unsafe.Pointer, iter *Iterato
 			break
 		}
 	}
-	if iter.Error != nil && iter.Error != io.EOF {
+	if iter.Error != nil && iter.Error != io.EOF && len(decoder.typ.Type1().Name()) != 0 {
 		iter.Error = fmt.Errorf("%v.%s", decoder.typ, iter.Error.Error())
 	}
 	iter.decrementDepth()
@@ -748,7 +748,7 @@ func (decoder *fiveFieldsStructDecoder) Decode(ptr unsafe.Pointer, iter *Iterato
 			break
 		}
 	}
-	if iter.Error != nil && iter.Error != io.EOF {
+	if iter.Error != nil && iter.Error != io.EOF && len(decoder.typ.Type1().Name()) != 0 {
 		iter.Error = fmt.Errorf("%v.%s", decoder.typ, iter.Error.Error())
 	}
 	iter.decrementDepth()
@@ -798,7 +798,7 @@ func (decoder *sixFieldsStructDecoder) Decode(ptr unsafe.Pointer, iter *Iterator
 			break
 		}
 	}
-	if iter.Error != nil && iter.Error != io.EOF {
+	if iter.Error != nil && iter.Error != io.EOF && len(decoder.typ.Type1().Name()) != 0 {
 		iter.Error = fmt.Errorf("%v.%s", decoder.typ, iter.Error.Error())
 	}
 	iter.decrementDepth()
@@ -852,7 +852,7 @@ func (decoder *sevenFieldsStructDecoder) Decode(ptr unsafe.Pointer, iter *Iterat
 			break
 		}
 	}
-	if iter.Error != nil && iter.Error != io.EOF {
+	if iter.Error != nil && iter.Error != io.EOF && len(decoder.typ.Type1().Name()) != 0 {
 		iter.Error = fmt.Errorf("%v.%s", decoder.typ, iter.Error.Error())
 	}
 	iter.decrementDepth()
@@ -910,7 +910,7 @@ func (decoder *eightFieldsStructDecoder) Decode(ptr unsafe.Pointer, iter *Iterat
 			break
 		}
 	}
-	if iter.Error != nil && iter.Error != io.EOF {
+	if iter.Error != nil && iter.Error != io.EOF && len(decoder.typ.Type1().Name()) != 0 {
 		iter.Error = fmt.Errorf("%v.%s", decoder.typ, iter.Error.Error())
 	}
 	iter.decrementDepth()
@@ -972,7 +972,7 @@ func (decoder *nineFieldsStructDecoder) Decode(ptr unsafe.Pointer, iter *Iterato
 			break
 		}
 	}
-	if iter.Error != nil && iter.Error != io.EOF {
+	if iter.Error != nil && iter.Error != io.EOF && len(decoder.typ.Type1().Name()) != 0 {
 		iter.Error = fmt.Errorf("%v.%s", decoder.typ, iter.Error.Error())
 	}
 	iter.decrementDepth()
@@ -1038,7 +1038,7 @@ func (decoder *tenFieldsStructDecoder) Decode(ptr unsafe.Pointer, iter *Iterator
 			break
 		}
 	}
-	if iter.Error != nil && iter.Error != io.EOF {
+	if iter.Error != nil && iter.Error != io.EOF && len(decoder.typ.Type1().Name()) != 0 {
 		iter.Error = fmt.Errorf("%v.%s", decoder.typ, iter.Error.Error())
 	}
 	iter.decrementDepth()


### PR DESCRIPTION
If a struct's type is anonymous, the decoder should not return an error message with its definition when it meets an error.