### PR TITLE
(*Stream).WriteMore: do not Flush

### DIFF
--- a/benchmarks/stream_test.go
+++ b/benchmarks/stream_test.go
@@ -1,0 +1,128 @@
+package test
+
+import (
+	"bytes"
+	"strconv"
+	"testing"
+
+	jsoniter "github.com/json-iterator/go"
+)
+
+func Benchmark_stream_encode_big_object(b *testing.B) {
+	var buf bytes.Buffer
+	var stream = jsoniter.NewStream(jsoniter.ConfigDefault, &buf, 100)
+	for i := 0; i < b.N; i++ {
+		buf.Reset()
+		stream.Reset(&buf)
+		encodeObject(stream)
+		if stream.Error != nil {
+			b.Errorf("error: %+v", stream.Error)
+		}
+	}
+}
+
+func TestEncodeObject(t *testing.T) {
+	var stream = jsoniter.NewStream(jsoniter.ConfigDefault, nil, 100)
+	encodeObject(stream)
+	if stream.Error != nil {
+		t.Errorf("error encoding a test object: %+v", stream.Error)
+		return
+	}
+	var m = make(map[string]interface{})
+	if err := jsoniter.Unmarshal(stream.Buffer(), &m); err != nil {
+		t.Errorf("error unmarshaling a test object: %+v", err)
+		return
+	}
+}
+
+func encodeObject(stream *jsoniter.Stream) {
+	stream.WriteObjectStart()
+
+	stream.WriteObjectField("objectId")
+	stream.WriteUint64(8838243212)
+
+	stream.WriteMore()
+	stream.WriteObjectField("name")
+	stream.WriteString("Jane Doe")
+
+	stream.WriteMore()
+	stream.WriteObjectField("address")
+	stream.WriteObjectStart()
+	for i, field := range addressFields {
+		if i != 0 {
+			stream.WriteMore()
+		}
+		stream.WriteObjectField(field.key)
+		stream.WriteString(field.val)
+	}
+
+	stream.WriteMore()
+	stream.WriteObjectField("geo")
+	{
+		stream.WriteObjectStart()
+		stream.WriteObjectField("latitude")
+		stream.WriteFloat64(-154.550817)
+		stream.WriteMore()
+		stream.WriteObjectField("longitude")
+		stream.WriteFloat64(-84.176159)
+		stream.WriteObjectEnd()
+
+	}
+	stream.WriteObjectEnd()
+
+	stream.WriteMore()
+	stream.WriteObjectField("specialties")
+	stream.WriteArrayStart()
+	for i, s := range specialties {
+		if i != 0 {
+			stream.WriteMore()
+		}
+		stream.WriteString(s)
+	}
+	stream.WriteArrayEnd()
+
+	stream.WriteMore()
+	for i, text := range longText {
+		if i != 0 {
+			stream.WriteMore()
+		}
+		stream.WriteObjectField("longText" + strconv.Itoa(i))
+		stream.WriteString(text)
+	}
+
+	for i := 0; i < 25; i++ {
+		num := i * 18328
+		stream.WriteMore()
+		stream.WriteObjectField("integerField" + strconv.Itoa(i))
+		stream.WriteInt64(int64(num))
+	}
+
+	stream.WriteObjectEnd()
+}
+
+type field struct{ key, val string }
+
+var (
+	addressFields = []field{
+		{"address1", "123 Example St"},
+		{"address2", "Apartment 5D, Suite 3"},
+		{"city", "Miami"},
+		{"state", "FL"},
+		{"postalCode", "33133"},
+		{"country", "US"},
+	}
+	specialties = []string{
+		"Web Design",
+		"Go Programming",
+		"Tennis",
+		"Cycling",
+		"Mixed martial arts",
+	}
+	longText = []string{
+		`Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.`,
+		`Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo. Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt. Neque porro quisquam est, qui dolorem ipsum quia dolor sit amet, consectetur, adipisci velit, sed quia non numquam eius modi tempora incidunt ut labore et dolore magnam aliquam quaerat voluptatem. Ut enim ad minima veniam, quis nostrum exercitationem ullam corporis suscipit laboriosam, nisi ut aliquid ex ea commodi consequatur? Quis autem vel eum iure reprehenderit qui in ea voluptate velit esse quam nihil molestiae consequatur, vel illum qui dolorem eum fugiat quo voluptas nulla pariatur?`,
+		`But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure. To take a trivial example, which of us ever undertakes laborious physical exercise, except to obtain some advantage from it? But who has any right to find fault with a man who chooses to enjoy a pleasure that has no annoying consequences, or one who avoids a pain that produces no resultant pleasure?`,
+		`At vero eos et accusamus et iusto odio dignissimos ducimus qui blanditiis praesentium voluptatum deleniti atque corrupti quos dolores et quas molestias excepturi sint occaecati cupiditate non provident, similique sunt in culpa qui officia deserunt mollitia animi, id est laborum et dolorum fuga. Et harum quidem rerum facilis est et expedita distinctio. Nam libero tempore, cum soluta nobis est eligendi optio cumque nihil impedit quo minus id quod maxime placeat facere possimus, omnis voluptas assumenda est, omnis dolor repellendus. Temporibus autem quibusdam et aut officiis debitis aut rerum necessitatibus saepe eveniet ut et voluptates repudiandae sint et molestiae non recusandae. Itaque earum rerum hic tenetur a sapiente delectus, ut aut reiciendis voluptatibus maiores alias consequatur aut perferendis doloribus asperiores repellat.`,
+		`On the other hand, we denounce with righteous indignation and dislike men who are so beguiled and demoralized by the charms of pleasure of the moment, so blinded by desire, that they cannot foresee the pain and trouble that are bound to ensue; and equal blame belongs to those who fail in their duty through weakness of will, which is the same as saying through shrinking from toil and pain. These cases are perfectly simple and easy to distinguish. In a free hour, when our power of choice is untrammelled and when nothing prevents our being able to do what we like best, every pleasure is to be welcomed and every pain avoided. But in certain circumstances and owing to the claims of duty or the obligations of business it will frequently occur that pleasures have to be repudiated and annoyances accepted. The wise man therefore always holds in these matters to this principle of selection: he rejects pleasures to secure other greater pleasures, or else he endures pains to avoid worse pains.`,
+	}
+)

--- a/stream.go
+++ b/stream.go
@@ -177,7 +177,6 @@ func (stream *Stream) WriteEmptyObject() {
 func (stream *Stream) WriteMore() {
 	stream.writeByte(',')
 	stream.writeIndention(0)
-	stream.Flush()
 }
 
 // WriteArrayStart write [ with possible indention

--- a/stream.go
+++ b/stream.go
@@ -103,14 +103,14 @@ func (stream *Stream) Flush() error {
 	if stream.Error != nil {
 		return stream.Error
 	}
-	n, err := stream.out.Write(stream.buf)
+	_, err := stream.out.Write(stream.buf)
 	if err != nil {
 		if stream.Error == nil {
 			stream.Error = err
 		}
 		return err
 	}
-	stream.buf = stream.buf[n:]
+	stream.buf = stream.buf[:0]
 	return nil
 }
 

--- a/stream_test.go
+++ b/stream_test.go
@@ -63,8 +63,19 @@ func (w *NopWriter) Write(p []byte) (n int, err error) {
 }
 
 func Test_flush_buffer_should_stop_grow_buffer(t *testing.T) {
+	// Stream an array of a zillion zeros.
 	writer := new(NopWriter)
-	NewEncoder(writer).Encode(make([]int, 10000000))
+	stream := NewStream(ConfigDefault, writer, 512)
+	stream.WriteArrayStart()
+	for i := 0; i < 10000000; i++ {
+		stream.WriteInt(0)
+		stream.WriteMore()
+		stream.Flush()
+	}
+	stream.WriteInt(0)
+	stream.WriteArrayEnd()
+
+	// Confirm that the buffer didn't have to grow.
 	should := require.New(t)
 
 	// 512 is the internal buffer size set in NewEncoder

--- a/stream_test.go
+++ b/stream_test.go
@@ -1,8 +1,9 @@
 package jsoniter
 
 import (
-	"github.com/stretchr/testify/require"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func Test_writeByte_should_grow_buffer(t *testing.T) {
@@ -65,5 +66,10 @@ func Test_flush_buffer_should_stop_grow_buffer(t *testing.T) {
 	writer := new(NopWriter)
 	NewEncoder(writer).Encode(make([]int, 10000000))
 	should := require.New(t)
-	should.Equal(8, writer.bufferSize)
+
+	// 512 is the internal buffer size set in NewEncoder
+	//
+	// Flush is called after each array element, so only the first 8 bytes of it
+	// is ever used, and it is never extended. Capacity remains 512.
+	should.Equal(512, writer.bufferSize)
 }


### PR DESCRIPTION
I believe that WriteMore should not call Flush for these reasons:

1. This is surprising for users because of inconsistency. Why call Flush in WriteMore and not in WriteObjectEnd?
2. It is not necessary; callers are free to call Flush if their use case demands it.
3. It harms performance in the common case by flushing the buffer much more frequently than it needs to be flushed.

The stream benchmark shows a 7% benefit to removing the Flush call, and I
observed a similar speedup in my real-world use case.

    benchmark                                        old ns/op     new ns/op     delta
    Benchmark_encode_string_with_SetEscapeHTML-8     442           437           -1.13%
    Benchmark_jsoniter_large_file-8                  21222         21062         -0.75%
    Benchmark_json_large_file-8                      40187         40266         +0.20%
    Benchmark_stream_encode_big_object-8             8611          7956          -7.61%

    benchmark                                        old allocs     new allocs     delta
    Benchmark_encode_string_with_SetEscapeHTML-8     6              6              +0.00%
    Benchmark_jsoniter_large_file-8                  78             78             +0.00%
    Benchmark_json_large_file-8                      13             13             +0.00%
    Benchmark_stream_encode_big_object-8             0              0              +0.00%

    benchmark                                        old bytes     new bytes     delta
    Benchmark_encode_string_with_SetEscapeHTML-8     760           760           +0.00%
    Benchmark_jsoniter_large_file-8                  4920          4920          +0.00%
    Benchmark_json_large_file-8                      6640          6640          +0.00%
    Benchmark_stream_encode_big_object-8             0             0             +0.00%

Backwards compatibility - I believe there is little to no risk that this breaks
callers. WriteMore does not leave the JSON in a valid state, so it must be
followed by other Write* methods. To get the finished JSON out, the caller must
already be calling Flush.