### PR TITLE
Move to sync.Map

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
-  - 1.8.x
+  - 1.9.x
   - 1.x
 
 before_install:

--- a/config.go
+++ b/config.go
@@ -7,7 +7,6 @@ import (
 	"sync"
 	"unsafe"
 
-	"github.com/modern-go/concurrent"
 	"github.com/modern-go/reflect2"
 )
 
@@ -72,8 +71,8 @@ type frozenConfig struct {
 	objectFieldMustBeSimpleString bool
 	onlyTaggedField               bool
 	disallowUnknownFields         bool
-	decoderCache                  *concurrent.Map
-	encoderCache                  *concurrent.Map
+	decoderCache                  *sync.Map
+	encoderCache                  *sync.Map
 	encoderExtension              Extension
 	decoderExtension              Extension
 	extraExtensions               []Extension
@@ -83,8 +82,8 @@ type frozenConfig struct {
 }
 
 func (cfg *frozenConfig) initCache() {
-	cfg.decoderCache = concurrent.NewMap()
-	cfg.encoderCache = concurrent.NewMap()
+	cfg.decoderCache = new(sync.Map)
+	cfg.encoderCache = new(sync.Map)
 }
 
 func (cfg *frozenConfig) addDecoderToCache(cacheKey uintptr, decoder ValDecoder) {
@@ -111,7 +110,7 @@ func (cfg *frozenConfig) getEncoderFromCache(cacheKey uintptr) ValEncoder {
 	return nil
 }
 
-var cfgCache = concurrent.NewMap()
+var cfgCache = new(sync.Map)
 
 func getFrozenConfigFromCache(cfg Config) *frozenConfig {
 	obj, found := cfgCache.Load(cfg)

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.12
 require (
 	github.com/davecgh/go-spew v1.1.1
 	github.com/google/gofuzz v1.0.0
-	github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421
+	github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421 // indirect
 	github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742
 	github.com/stretchr/testify v1.3.0
 )


### PR DESCRIPTION
Go 1.9 (released in August 2017) added sync.Map. The release has been
around some time (and the release is not even supported by the Go
developers anymore) so it's safe to make a claim sync.Map is available for
everyone.

This commit keeps ./test.sh passing.

Fixes: #446

Signed-off-by: Mikko Ylinen <mikko.ylinen@intel.com>