### PR TITLE
Get中传入[]interface{}参数时，无法得到结果

### DIFF
--- a/adapter.go
+++ b/adapter.go
@@ -26,6 +26,10 @@ func Get(data []byte, path ...interface{}) Any {
 	return ConfigDefault.Get(data, path...)
 }
 
+func Gets(data[] byte,path []interface{}) Any{
+	return ConfigDefault.Gets(data,path)
+}
+
 // Marshal adapts to json/encoding Marshal API
 //
 // Marshal returns the JSON encoding of v, adapts to json/encoding Marshal API

--- a/config.go
+++ b/config.go
@@ -38,6 +38,7 @@ type API interface {
 	UnmarshalFromString(str string, v interface{}) error
 	Unmarshal(data []byte, v interface{}) error
 	Get(data []byte, path ...interface{}) Any
+	Gets(data []byte,path []interface{}) Any
 	NewEncoder(writer io.Writer) *Encoder
 	NewDecoder(reader io.Reader) *Decoder
 	Valid(data []byte) bool
@@ -341,6 +342,15 @@ func (cfg *frozenConfig) Get(data []byte, path ...interface{}) Any {
 	defer cfg.ReturnIterator(iter)
 	return locatePath(iter, path)
 }
+
+func (cfg *frozenConfig) Gets(data []byte, path []interface{}) Any {
+	iter := cfg.BorrowIterator(data)
+	defer cfg.ReturnIterator(iter)
+	return locatePath(iter, path)
+}
+
+
+
 
 func (cfg *frozenConfig) Unmarshal(data []byte, v interface{}) error {
 	iter := cfg.BorrowIterator(data)

--- a/example_test.go
+++ b/example_test.go
@@ -90,7 +90,15 @@ func ExampleConfigFastest_Unmarshal() {
 
 func ExampleGet() {
 	val := []byte(`{"ID":1,"Name":"Reds","Colors":["Crimson","Red","Ruby","Maroon"]}`)
-	fmt.Printf(Get(val, "Colors", 0).ToString())
+
+	v := Get(val, "Colors", 0).ToString()
+	fmt.Printf(v)
+
+	v2 := Get(val, []interface{}{"Colors",0}).ToString()
+	fmt.Println(v2)
+
+	v3 := Gets(val, []interface{}{"Colors",0}).ToString()
+	fmt.Println(v3)
 	// Output:
 	// Crimson
 }


### PR DESCRIPTION
现象：
Get方法中直接传入[]interface{}参数，无法得到结果。

解决方式：
新增函数（和API）Gets，参数类型是[]interface{} 而不是 ...interface{}，实现同Get

PS：
Go为毛不能重载～