### PR TITLE
Added Config.AllowOmitEmptyStruct

### DIFF
--- a/config.go
+++ b/config.go
@@ -29,6 +29,7 @@ type Config struct {
 	ObjectFieldMustBeSimpleString bool
 	CaseSensitive                 bool
 	MaxDepth                      int
+	AllowOmitEmptyStruct          bool
 }
 
 // API the public interface of this package.
@@ -86,6 +87,7 @@ type frozenConfig struct {
 	iteratorPool                  *sync.Pool
 	caseSensitive                 bool
 	maxDepth                      int
+	allowOmitEmptyStruct          bool
 }
 
 func (cfg *frozenConfig) initCache() {
@@ -144,6 +146,7 @@ func (cfg Config) Froze() API {
 		disallowUnknownFields:         cfg.DisallowUnknownFields,
 		caseSensitive:                 cfg.CaseSensitive,
 		maxDepth:                      cfg.MaxDepth,
+		allowOmitEmptyStruct:          cfg.AllowOmitEmptyStruct,
 	}
 	api.streamPool = &sync.Pool{
 		New: func() interface{} {


### PR DESCRIPTION
Optionally allow omitempty to apply to an empty (zero value) struct, disabled by default.
Useful when there are a lot of empty structs that are often not used. I am not a fan of using pointers just for this side effect.
I can add tests if there is interest.
