### PR TITLE
Map keys of custom types should serialize using MarshalText when available

### DIFF
--- a/misc_tests/jsoniter_map_test.go
+++ b/misc_tests/jsoniter_map_test.go
@@ -50,3 +50,20 @@ func Test_encode_nil_map(t *testing.T) {
 	should.NoError(err)
 	should.Equal(`null`, output)
 }
+
+func Test_WhenMapKeyIsCustomType_AndImplementsTextMarshaler_MarshalTextIsUsed(t *testing.T) {
+	should := require.New(t)
+	input := map[customKey]string{customKey(1): "bar"}
+	jsoniterOutput, err := jsoniter.Marshal(input)
+	encodingJSONOutput, err := json.Marshal(input)
+
+	should.NoError(err)
+	should.Equal(encodingJSONOutput, jsoniterOutput)
+	should.Equal(`{"foo":"bar"}`, string(jsoniterOutput))
+}
+
+type customKey int32
+
+func (c customKey) MarshalText() ([]byte, error) {
+	return []byte("foo"), nil
+}

--- a/misc_tests/jsoniter_map_test.go
+++ b/misc_tests/jsoniter_map_test.go
@@ -50,20 +50,3 @@ func Test_encode_nil_map(t *testing.T) {
 	should.NoError(err)
 	should.Equal(`null`, output)
 }
-
-func Test_WhenMapKeyIsCustomType_AndImplementsTextMarshaler_MarshalTextIsUsed(t *testing.T) {
-	should := require.New(t)
-	input := map[customKey]string{customKey(1): "bar"}
-	jsoniterOutput, err := jsoniter.Marshal(input)
-	encodingJSONOutput, err := json.Marshal(input)
-
-	should.NoError(err)
-	should.Equal(encodingJSONOutput, jsoniterOutput)
-	should.Equal(`{"foo":"bar"}`, string(jsoniterOutput))
-}
-
-type customKey int32
-
-func (c customKey) MarshalText() ([]byte, error) {
-	return []byte("foo"), nil
-}

--- a/reflect_map.go
+++ b/reflect_map.go
@@ -103,6 +103,19 @@ func encoderOfMapKey(ctx *ctx, typ reflect2.Type) ValEncoder {
 			return encoder
 		}
 	}
+
+	if typ == textMarshalerType {
+		return &directTextMarshalerEncoder{
+			stringEncoder: ctx.EncoderOf(reflect2.TypeOf("")),
+		}
+	}
+	if typ.Implements(textMarshalerType) {
+		return &textMarshalerEncoder{
+			valType:       typ,
+			stringEncoder: ctx.EncoderOf(reflect2.TypeOf("")),
+		}
+	}
+
 	switch typ.Kind() {
 	case reflect.String:
 		return encoderOfType(ctx, reflect2.DefaultTypeOfKind(reflect.String))
@@ -117,17 +130,6 @@ func encoderOfMapKey(ctx *ctx, typ reflect2.Type) ValEncoder {
 		typ = reflect2.DefaultTypeOfKind(typ.Kind())
 		return &numericMapKeyEncoder{encoderOfType(ctx, typ)}
 	default:
-		if typ == textMarshalerType {
-			return &directTextMarshalerEncoder{
-				stringEncoder: ctx.EncoderOf(reflect2.TypeOf("")),
-			}
-		}
-		if typ.Implements(textMarshalerType) {
-			return &textMarshalerEncoder{
-				valType:       typ,
-				stringEncoder: ctx.EncoderOf(reflect2.TypeOf("")),
-			}
-		}
 		if typ.Kind() == reflect.Interface {
 			return &dynamicMapKeyEncoder{ctx, typ}
 		}

--- a/value_tests/map_test.go
+++ b/value_tests/map_test.go
@@ -31,6 +31,7 @@ func init() {
 		map[string]*json.RawMessage{"hello": pRawMessage(json.RawMessage("[]"))},
 		map[Date]bool{{}: true},
 		map[Date2]bool{{}: true},
+		map[customKey]string{customKey(1): "bar"},
 	)
 	unmarshalCases = append(unmarshalCases, unmarshalCase{
 		ptr:   (*map[string]string)(nil),
@@ -55,6 +56,9 @@ func init() {
         "2018-12-13": true,
         "2018-12-14": true
     	}`,
+	}, unmarshalCase{
+		ptr: (*map[customKey]string)(nil),
+		input: `{"foo": "bar"}`,
 	})
 }
 
@@ -114,4 +118,15 @@ func (d Date2) UnmarshalJSON(b []byte) error {
 
 func (d Date2) MarshalJSON() ([]byte, error) {
 	return []byte(d.Time.Format("2006-01-02")), nil
+}
+
+type customKey int32
+
+func (c customKey) MarshalText() ([]byte, error) {
+	return []byte("foo"), nil
+}
+
+func (c *customKey) UnmarshalText(value []byte) error {
+	*c = 1
+	return nil
 }


### PR DESCRIPTION
This is to address the issue filed [here](https://github.com/json-iterator/go/issues/459).