### PR TITLE
Add new API iter.CurrentBufferSize()

### DIFF
--- a/iter.go
+++ b/iter.go
@@ -235,6 +235,11 @@ func (iter *Iterator) CurrentBuffer() string {
 		string(iter.buf[peekStart:iter.head]), string(iter.buf[0:iter.tail]))
 }
 
+// CurrentBufferSize gets the number if bytes currently in the buffer
+func (iter *Iterator) CurrentBufferSize() int {
+	return iter.tail - iter.head
+}
+
 func (iter *Iterator) readByte() (ret byte) {
 	if iter.head == iter.tail {
 		if iter.loadMore() {


### PR DESCRIPTION
I am working on a project where it would be immensely useful to know how many bytes (approximately) each JSON object we pull of an iterator used. We can almost do this by passing in a io.Reader that counts the number of bytes read, but we still need to discount for anything in the buffer. With this simple API addition this is possible.

Alternatively we could count all bytes read, and provide an InputOffset() method like the stdlib json.Decoder, but that feels like going over the top?