### PR TITLE
Make Marshal(RawMessage) behave like encoding/json

### DIFF
--- a/adapter.go
+++ b/adapter.go
@@ -3,10 +3,26 @@ package jsoniter
 import (
 	"bytes"
 	"io"
+	"errors"
 )
 
 // RawMessage to make replace json with jsoniter
 type RawMessage []byte
+
+func (m RawMessage) MarshalJSON() ([]byte, error) {
+	if m == nil {
+		return []byte("null"), nil
+	}
+	return m, nil
+}
+
+func (m *RawMessage) UnmarshalJSON(data []byte) error {
+	if m == nil {
+		return errors.New("json.RawMessage: UnmarshalJSON on nil pointer")
+	}
+	*m = append((*m)[0:0], data...)
+	return nil
+}
 
 // Unmarshal adapts to json/encoding Unmarshal API
 //


### PR DESCRIPTION
In encoding/json, there is MarshalJSON() and UnmarshaslJSON() for RawMessage. Missing this two method leads to different behavior while Marshal() jsoniter.RawMessage using std json package.

Example code below
```
package main
import (
    "fmt"
    "encoding/json"
    "github.com/json-iterator/go"
)

type T struct {
    Msg jsoniter.RawMessage
}

func main() {
    var j T
    
    raw := []byte(`{ "Msg": {"Foo": "Bar"}}`)
    
    jsoniter.Unmarshal(raw, &j)
        
    b1, _ := json.Marshal(j.Msg)
    fmt.Printf("%s\n", b1)                         /// Expect `{"Foo": "Bar"}` but got `"IHsiRm9vIjogIkJhciJ9"`
    
    b2, _ := jsoniter.Marshal(j.Msg)
    fmt.Printf("%s\n", b2)
}
```