### PR TITLE
fixed null in number json tag string

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -9,6 +9,7 @@ github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742 h1:Esafd1046DLD
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=

--- a/reflect_struct_decoder.go
+++ b/reflect_struct_decoder.go
@@ -1075,6 +1075,11 @@ type stringModeNumberDecoder struct {
 }
 
 func (decoder *stringModeNumberDecoder) Decode(ptr unsafe.Pointer, iter *Iterator) {
+	if iter.WhatIsNext() == NilValue {
+		decoder.elemDecoder.Decode(ptr, iter)
+		return
+	}
+
 	c := iter.nextToken()
 	if c != '"' {
 		iter.ReportError("stringModeNumberDecoder", `expect ", but found `+string([]byte{c}))

--- a/value_tests/struct_test.go
+++ b/value_tests/struct_test.go
@@ -28,6 +28,11 @@ func init() {
 		input: `{"field": null}`,
 	}, unmarshalCase{
 		ptr: (*struct {
+			Field int `json:"field,string"`
+		})(nil),
+		input: `{"field": null}`,
+	}, unmarshalCase{
+		ptr: (*struct {
 			ID      int                    `json:"id"`
 			Payload map[string]interface{} `json:"payload"`
 			buf     *bytes.Buffer


### PR DESCRIPTION
This fixes recently reported [bug](https://github.com/json-iterator/go/issues/478), when null is passed to number with json tag set to string. As highlighted in issue, standard library will place zero value in such case ([GoPlayground](https://play.golang.org/p/FyR6I63Ok0k)). However, `json-iterator` previously crashed with error like this:

```

--- FAIL: Test_unmarshal (0.00s)
    --- FAIL: Test_unmarshal/[41]{"field":_null} (0.00s)
        require.go:794: 
            	Error Trace:	value_test.go:52
            	Error:      	Received unexpected error:
            	            	Field: stringModeNumberDecoder: expect ", but found n, error found in #10 byte of ...|"field": null}|..., bigger context ...|{"field": null}|...
            	Test:       	Test_unmarshal/[41]{"field":_null}
            	Messages:   	jsoniter
```

Test plan:
- [x] added test that fails without this modification
- [x] all other tests pass 