### PR TITLE
exporting nextToken() allows custom Unmarshal implementation

### DIFF
--- a/adapter.go
+++ b/adapter.go
@@ -81,7 +81,7 @@ func (adapter *Decoder) More() bool {
 	if iter.Error != nil {
 		return false
 	}
-	c := iter.nextToken()
+	c := iter.NextToken()
 	if c == 0 {
 		return false
 	}

--- a/any.go
+++ b/any.go
@@ -151,7 +151,7 @@ func (iter *Iterator) ReadAny() Any {
 }
 
 func (iter *Iterator) readAny() Any {
-	c := iter.nextToken()
+	c := iter.NextToken()
 	switch c {
 	case '"':
 		iter.unreadByte()

--- a/config.go
+++ b/config.go
@@ -325,7 +325,7 @@ func (cfg *frozenConfig) UnmarshalFromString(str string, v interface{}) error {
 	iter := cfg.BorrowIterator(data)
 	defer cfg.ReturnIterator(iter)
 	iter.ReadVal(v)
-	c := iter.nextToken()
+	c := iter.NextToken()
 	if c == 0 {
 		if iter.Error == io.EOF {
 			return nil
@@ -346,7 +346,7 @@ func (cfg *frozenConfig) Unmarshal(data []byte, v interface{}) error {
 	iter := cfg.BorrowIterator(data)
 	defer cfg.ReturnIterator(iter)
 	iter.ReadVal(v)
-	c := iter.nextToken()
+	c := iter.NextToken()
 	if c == 0 {
 		if iter.Error == io.EOF {
 			return nil

--- a/iter.go
+++ b/iter.go
@@ -148,7 +148,7 @@ func (iter *Iterator) ResetBytes(input []byte) *Iterator {
 
 // WhatIsNext gets ValueType of relatively next json element
 func (iter *Iterator) WhatIsNext() ValueType {
-	valueType := valueTypes[iter.nextToken()]
+	valueType := valueTypes[iter.NextToken()]
 	iter.unreadByte()
 	return valueType
 }
@@ -167,7 +167,7 @@ func (iter *Iterator) skipWhitespacesWithoutLoadMore() bool {
 }
 
 func (iter *Iterator) isObjectEnd() bool {
-	c := iter.nextToken()
+	c := iter.NextToken()
 	if c == ',' {
 		return false
 	}
@@ -178,7 +178,7 @@ func (iter *Iterator) isObjectEnd() bool {
 	return true
 }
 
-func (iter *Iterator) nextToken() byte {
+func (iter *Iterator) NextToken() byte {
 	// a variation of skip whitespaces, returning the next non-whitespace token
 	for {
 		for i := iter.head; i < iter.tail; i++ {

--- a/iter_array.go
+++ b/iter_array.go
@@ -2,13 +2,13 @@ package jsoniter
 
 // ReadArray read array element, tells if the array has more element to read.
 func (iter *Iterator) ReadArray() (ret bool) {
-	c := iter.nextToken()
+	c := iter.NextToken()
 	switch c {
 	case 'n':
 		iter.skipThreeBytes('u', 'l', 'l')
 		return false // null
 	case '[':
-		c = iter.nextToken()
+		c = iter.NextToken()
 		if c != ']' {
 			iter.unreadByte()
 			return true
@@ -26,25 +26,25 @@ func (iter *Iterator) ReadArray() (ret bool) {
 
 // ReadArrayCB read array with callback
 func (iter *Iterator) ReadArrayCB(callback func(*Iterator) bool) (ret bool) {
-	c := iter.nextToken()
+	c := iter.NextToken()
 	if c == '[' {
 		if !iter.incrementDepth() {
 			return false
 		}
-		c = iter.nextToken()
+		c = iter.NextToken()
 		if c != ']' {
 			iter.unreadByte()
 			if !callback(iter) {
 				iter.decrementDepth()
 				return false
 			}
-			c = iter.nextToken()
+			c = iter.NextToken()
 			for c == ',' {
 				if !callback(iter) {
 					iter.decrementDepth()
 					return false
 				}
-				c = iter.nextToken()
+				c = iter.NextToken()
 			}
 			if c != ']' {
 				iter.ReportError("ReadArrayCB", "expect ] in the end, but found "+string([]byte{c}))

--- a/iter_float.go
+++ b/iter_float.go
@@ -68,7 +68,7 @@ func (iter *Iterator) ReadBigInt() (ret *big.Int) {
 
 //ReadFloat32 read float32
 func (iter *Iterator) ReadFloat32() (ret float32) {
-	c := iter.nextToken()
+	c := iter.NextToken()
 	if c == '-' {
 		return -iter.readPositiveFloat32()
 	}
@@ -205,7 +205,7 @@ func (iter *Iterator) readFloat32SlowPath() (ret float32) {
 
 // ReadFloat64 read float64
 func (iter *Iterator) ReadFloat64() (ret float64) {
-	c := iter.nextToken()
+	c := iter.NextToken()
 	if c == '-' {
 		return -iter.readPositiveFloat64()
 	}

--- a/iter_int.go
+++ b/iter_int.go
@@ -38,7 +38,7 @@ func (iter *Iterator) ReadInt() int {
 
 // ReadInt8 read int8
 func (iter *Iterator) ReadInt8() (ret int8) {
-	c := iter.nextToken()
+	c := iter.NextToken()
 	if c == '-' {
 		val := iter.readUint32(iter.readByte())
 		if val > math.MaxInt8+1 {
@@ -57,7 +57,7 @@ func (iter *Iterator) ReadInt8() (ret int8) {
 
 // ReadUint8 read uint8
 func (iter *Iterator) ReadUint8() (ret uint8) {
-	val := iter.readUint32(iter.nextToken())
+	val := iter.readUint32(iter.NextToken())
 	if val > math.MaxUint8 {
 		iter.ReportError("ReadUint8", "overflow: "+strconv.FormatInt(int64(val), 10))
 		return
@@ -67,7 +67,7 @@ func (iter *Iterator) ReadUint8() (ret uint8) {
 
 // ReadInt16 read int16
 func (iter *Iterator) ReadInt16() (ret int16) {
-	c := iter.nextToken()
+	c := iter.NextToken()
 	if c == '-' {
 		val := iter.readUint32(iter.readByte())
 		if val > math.MaxInt16+1 {
@@ -86,7 +86,7 @@ func (iter *Iterator) ReadInt16() (ret int16) {
 
 // ReadUint16 read uint16
 func (iter *Iterator) ReadUint16() (ret uint16) {
-	val := iter.readUint32(iter.nextToken())
+	val := iter.readUint32(iter.NextToken())
 	if val > math.MaxUint16 {
 		iter.ReportError("ReadUint16", "overflow: "+strconv.FormatInt(int64(val), 10))
 		return
@@ -96,7 +96,7 @@ func (iter *Iterator) ReadUint16() (ret uint16) {
 
 // ReadInt32 read int32
 func (iter *Iterator) ReadInt32() (ret int32) {
-	c := iter.nextToken()
+	c := iter.NextToken()
 	if c == '-' {
 		val := iter.readUint32(iter.readByte())
 		if val > math.MaxInt32+1 {
@@ -115,7 +115,7 @@ func (iter *Iterator) ReadInt32() (ret int32) {
 
 // ReadUint32 read uint32
 func (iter *Iterator) ReadUint32() (ret uint32) {
-	return iter.readUint32(iter.nextToken())
+	return iter.readUint32(iter.NextToken())
 }
 
 func (iter *Iterator) readUint32(c byte) (ret uint32) {
@@ -218,7 +218,7 @@ func (iter *Iterator) readUint32(c byte) (ret uint32) {
 
 // ReadInt64 read int64
 func (iter *Iterator) ReadInt64() (ret int64) {
-	c := iter.nextToken()
+	c := iter.NextToken()
 	if c == '-' {
 		val := iter.readUint64(iter.readByte())
 		if val > math.MaxInt64+1 {
@@ -237,7 +237,7 @@ func (iter *Iterator) ReadInt64() (ret int64) {
 
 // ReadUint64 read uint64
 func (iter *Iterator) ReadUint64() uint64 {
-	return iter.readUint64(iter.nextToken())
+	return iter.readUint64(iter.NextToken())
 }
 
 func (iter *Iterator) readUint64(c byte) (ret uint64) {

--- a/iter_object.go
+++ b/iter_object.go
@@ -9,17 +9,17 @@ import (
 // If object ended, returns empty string.
 // Otherwise, returns the field name.
 func (iter *Iterator) ReadObject() (ret string) {
-	c := iter.nextToken()
+	c := iter.NextToken()
 	switch c {
 	case 'n':
 		iter.skipThreeBytes('u', 'l', 'l')
 		return "" // null
 	case '{':
-		c = iter.nextToken()
+		c = iter.NextToken()
 		if c == '"' {
 			iter.unreadByte()
 			field := iter.ReadString()
-			c = iter.nextToken()
+			c = iter.NextToken()
 			if c != ':' {
 				iter.ReportError("ReadObject", "expect : after object field, but found "+string([]byte{c}))
 			}
@@ -32,7 +32,7 @@ func (iter *Iterator) ReadObject() (ret string) {
 		return
 	case ',':
 		field := iter.ReadString()
-		c = iter.nextToken()
+		c = iter.NextToken()
 		if c != ':' {
 			iter.ReportError("ReadObject", "expect : after object field, but found "+string([]byte{c}))
 		}
@@ -48,7 +48,7 @@ func (iter *Iterator) ReadObject() (ret string) {
 // CaseInsensitive
 func (iter *Iterator) readFieldHash() int64 {
 	hash := int64(0x811c9dc5)
-	c := iter.nextToken()
+	c := iter.NextToken()
 	if c != '"' {
 		iter.ReportError("readFieldHash", `expect ", but found `+string([]byte{c}))
 		return 0
@@ -66,7 +66,7 @@ func (iter *Iterator) readFieldHash() int64 {
 					hash ^= int64(b)
 					hash *= 0x1000193
 				}
-				c = iter.nextToken()
+				c = iter.NextToken()
 				if c != ':' {
 					iter.ReportError("readFieldHash", `expect :, but found `+string([]byte{c}))
 					return 0
@@ -75,7 +75,7 @@ func (iter *Iterator) readFieldHash() int64 {
 			}
 			if b == '"' {
 				iter.head = i + 1
-				c = iter.nextToken()
+				c = iter.NextToken()
 				if c != ':' {
 					iter.ReportError("readFieldHash", `expect :, but found `+string([]byte{c}))
 					return 0
@@ -109,17 +109,17 @@ func calcHash(str string, caseSensitive bool) int64 {
 
 // ReadObjectCB read object with callback, the key is ascii only and field name not copied
 func (iter *Iterator) ReadObjectCB(callback func(*Iterator, string) bool) bool {
-	c := iter.nextToken()
+	c := iter.NextToken()
 	var field string
 	if c == '{' {
 		if !iter.incrementDepth() {
 			return false
 		}
-		c = iter.nextToken()
+		c = iter.NextToken()
 		if c == '"' {
 			iter.unreadByte()
 			field = iter.ReadString()
-			c = iter.nextToken()
+			c = iter.NextToken()
 			if c != ':' {
 				iter.ReportError("ReadObject", "expect : after object field, but found "+string([]byte{c}))
 			}
@@ -127,10 +127,10 @@ func (iter *Iterator) ReadObjectCB(callback func(*Iterator, string) bool) bool {
 				iter.decrementDepth()
 				return false
 			}
-			c = iter.nextToken()
+			c = iter.NextToken()
 			for c == ',' {
 				field = iter.ReadString()
-				c = iter.nextToken()
+				c = iter.NextToken()
 				if c != ':' {
 					iter.ReportError("ReadObject", "expect : after object field, but found "+string([]byte{c}))
 				}
@@ -138,7 +138,7 @@ func (iter *Iterator) ReadObjectCB(callback func(*Iterator, string) bool) bool {
 					iter.decrementDepth()
 					return false
 				}
-				c = iter.nextToken()
+				c = iter.NextToken()
 			}
 			if c != '}' {
 				iter.ReportError("ReadObjectCB", `object not ended with }`)
@@ -164,16 +164,16 @@ func (iter *Iterator) ReadObjectCB(callback func(*Iterator, string) bool) bool {
 
 // ReadMapCB read map with callback, the key can be any string
 func (iter *Iterator) ReadMapCB(callback func(*Iterator, string) bool) bool {
-	c := iter.nextToken()
+	c := iter.NextToken()
 	if c == '{' {
 		if !iter.incrementDepth() {
 			return false
 		}
-		c = iter.nextToken()
+		c = iter.NextToken()
 		if c == '"' {
 			iter.unreadByte()
 			field := iter.ReadString()
-			if iter.nextToken() != ':' {
+			if iter.NextToken() != ':' {
 				iter.ReportError("ReadMapCB", "expect : after object field, but found "+string([]byte{c}))
 				iter.decrementDepth()
 				return false
@@ -182,10 +182,10 @@ func (iter *Iterator) ReadMapCB(callback func(*Iterator, string) bool) bool {
 				iter.decrementDepth()
 				return false
 			}
-			c = iter.nextToken()
+			c = iter.NextToken()
 			for c == ',' {
 				field = iter.ReadString()
-				if iter.nextToken() != ':' {
+				if iter.NextToken() != ':' {
 					iter.ReportError("ReadMapCB", "expect : after object field, but found "+string([]byte{c}))
 					iter.decrementDepth()
 					return false
@@ -194,7 +194,7 @@ func (iter *Iterator) ReadMapCB(callback func(*Iterator, string) bool) bool {
 					iter.decrementDepth()
 					return false
 				}
-				c = iter.nextToken()
+				c = iter.NextToken()
 			}
 			if c != '}' {
 				iter.ReportError("ReadMapCB", `object not ended with }`)
@@ -219,9 +219,9 @@ func (iter *Iterator) ReadMapCB(callback func(*Iterator, string) bool) bool {
 }
 
 func (iter *Iterator) readObjectStart() bool {
-	c := iter.nextToken()
+	c := iter.NextToken()
 	if c == '{' {
-		c = iter.nextToken()
+		c = iter.NextToken()
 		if c == '}' {
 			return false
 		}

--- a/iter_skip.go
+++ b/iter_skip.go
@@ -5,7 +5,7 @@ import "fmt"
 // ReadNil reads a json object as nil and
 // returns whether it's a nil or not
 func (iter *Iterator) ReadNil() (ret bool) {
-	c := iter.nextToken()
+	c := iter.NextToken()
 	if c == 'n' {
 		iter.skipThreeBytes('u', 'l', 'l') // null
 		return true
@@ -16,7 +16,7 @@ func (iter *Iterator) ReadNil() (ret bool) {
 
 // ReadBool reads a json object as BoolValue
 func (iter *Iterator) ReadBool() (ret bool) {
-	c := iter.nextToken()
+	c := iter.NextToken()
 	if c == 't' {
 		iter.skipThreeBytes('r', 'u', 'e')
 		return true
@@ -70,7 +70,7 @@ func (iter *Iterator) stopCapture() []byte {
 
 // Skip skips a json object and positions to relatively the next json object
 func (iter *Iterator) Skip() {
-	c := iter.nextToken()
+	c := iter.NextToken()
 	switch c {
 	case '"':
 		iter.skipString()

--- a/iter_str.go
+++ b/iter_str.go
@@ -7,7 +7,7 @@ import (
 
 // ReadString read string from iterator
 func (iter *Iterator) ReadString() (ret string) {
-	c := iter.nextToken()
+	c := iter.NextToken()
 	if c == '"' {
 		for i := iter.head; i < iter.tail; i++ {
 			c := iter.buf[i]
@@ -114,7 +114,7 @@ func (iter *Iterator) readEscapedChar(c byte, str []byte) []byte {
 // ReadStringAsSlice read string from iterator without copying into string form.
 // The []byte can not be kept, as it will change after next iterator call.
 func (iter *Iterator) ReadStringAsSlice() (ret []byte) {
-	c := iter.nextToken()
+	c := iter.NextToken()
 	if c == '"' {
 		for i := iter.head; i < iter.tail; i++ {
 			// require ascii string and no escape

--- a/reflect_array.go
+++ b/reflect_array.go
@@ -69,7 +69,7 @@ func (decoder *arrayDecoder) Decode(ptr unsafe.Pointer, iter *Iterator) {
 }
 
 func (decoder *arrayDecoder) doDecode(ptr unsafe.Pointer, iter *Iterator) {
-	c := iter.nextToken()
+	c := iter.NextToken()
 	arrayType := decoder.arrayType
 	if c == 'n' {
 		iter.skipThreeBytes('u', 'l', 'l')
@@ -79,7 +79,7 @@ func (decoder *arrayDecoder) doDecode(ptr unsafe.Pointer, iter *Iterator) {
 		iter.ReportError("decode array", "expect [ or n, but found "+string([]byte{c}))
 		return
 	}
-	c = iter.nextToken()
+	c = iter.NextToken()
 	if c == ']' {
 		return
 	}
@@ -87,7 +87,7 @@ func (decoder *arrayDecoder) doDecode(ptr unsafe.Pointer, iter *Iterator) {
 	elemPtr := arrayType.UnsafeGetIndex(ptr, 0)
 	decoder.elemDecoder.Decode(elemPtr, iter)
 	length := 1
-	for c = iter.nextToken(); c == ','; c = iter.nextToken() {
+	for c = iter.NextToken(); c == ','; c = iter.NextToken() {
 		if length >= arrayType.Len() {
 			iter.Skip()
 			continue

--- a/reflect_map.go
+++ b/reflect_map.go
@@ -149,7 +149,7 @@ type mapDecoder struct {
 
 func (decoder *mapDecoder) Decode(ptr unsafe.Pointer, iter *Iterator) {
 	mapType := decoder.mapType
-	c := iter.nextToken()
+	c := iter.NextToken()
 	if c == 'n' {
 		iter.skipThreeBytes('u', 'l', 'l')
 		*(*unsafe.Pointer)(ptr) = nil
@@ -163,14 +163,14 @@ func (decoder *mapDecoder) Decode(ptr unsafe.Pointer, iter *Iterator) {
 		iter.ReportError("ReadMapCB", `expect { or n, but found `+string([]byte{c}))
 		return
 	}
-	c = iter.nextToken()
+	c = iter.NextToken()
 	if c == '}' {
 		return
 	}
 	iter.unreadByte()
 	key := decoder.keyType.UnsafeNew()
 	decoder.keyDecoder.Decode(key, iter)
-	c = iter.nextToken()
+	c = iter.NextToken()
 	if c != ':' {
 		iter.ReportError("ReadMapCB", "expect : after object field, but found "+string([]byte{c}))
 		return
@@ -178,10 +178,10 @@ func (decoder *mapDecoder) Decode(ptr unsafe.Pointer, iter *Iterator) {
 	elem := decoder.elemType.UnsafeNew()
 	decoder.elemDecoder.Decode(elem, iter)
 	decoder.mapType.UnsafeSetIndex(ptr, key, elem)
-	for c = iter.nextToken(); c == ','; c = iter.nextToken() {
+	for c = iter.NextToken(); c == ','; c = iter.NextToken() {
 		key := decoder.keyType.UnsafeNew()
 		decoder.keyDecoder.Decode(key, iter)
-		c = iter.nextToken()
+		c = iter.NextToken()
 		if c != ':' {
 			iter.ReportError("ReadMapCB", "expect : after object field, but found "+string([]byte{c}))
 			return
@@ -200,13 +200,13 @@ type numericMapKeyDecoder struct {
 }
 
 func (decoder *numericMapKeyDecoder) Decode(ptr unsafe.Pointer, iter *Iterator) {
-	c := iter.nextToken()
+	c := iter.NextToken()
 	if c != '"' {
 		iter.ReportError("ReadMapCB", `expect ", but found `+string([]byte{c}))
 		return
 	}
 	decoder.decoder.Decode(ptr, iter)
-	c = iter.nextToken()
+	c = iter.NextToken()
 	if c != '"' {
 		iter.ReportError("ReadMapCB", `expect ", but found `+string([]byte{c}))
 		return

--- a/reflect_marshaler.go
+++ b/reflect_marshaler.go
@@ -193,7 +193,7 @@ func (decoder *unmarshalerDecoder) Decode(ptr unsafe.Pointer, iter *Iterator) {
 	valType := decoder.valType
 	obj := valType.UnsafeIndirect(ptr)
 	unmarshaler := obj.(json.Unmarshaler)
-	iter.nextToken()
+	iter.NextToken()
 	iter.unreadByte() // skip spaces
 	bytes := iter.SkipAndReturnBytes()
 	err := unmarshaler.UnmarshalJSON(bytes)

--- a/reflect_slice.go
+++ b/reflect_slice.go
@@ -64,7 +64,7 @@ func (decoder *sliceDecoder) Decode(ptr unsafe.Pointer, iter *Iterator) {
 }
 
 func (decoder *sliceDecoder) doDecode(ptr unsafe.Pointer, iter *Iterator) {
-	c := iter.nextToken()
+	c := iter.NextToken()
 	sliceType := decoder.sliceType
 	if c == 'n' {
 		iter.skipThreeBytes('u', 'l', 'l')
@@ -75,7 +75,7 @@ func (decoder *sliceDecoder) doDecode(ptr unsafe.Pointer, iter *Iterator) {
 		iter.ReportError("decode slice", "expect [ or n, but found "+string([]byte{c}))
 		return
 	}
-	c = iter.nextToken()
+	c = iter.NextToken()
 	if c == ']' {
 		sliceType.UnsafeSet(ptr, sliceType.UnsafeMakeSlice(0, 0))
 		return
@@ -85,7 +85,7 @@ func (decoder *sliceDecoder) doDecode(ptr unsafe.Pointer, iter *Iterator) {
 	elemPtr := sliceType.UnsafeGetIndex(ptr, 0)
 	decoder.elemDecoder.Decode(elemPtr, iter)
 	length := 1
-	for c = iter.nextToken(); c == ','; c = iter.nextToken() {
+	for c = iter.NextToken(); c == ','; c = iter.NextToken() {
 		idx := length
 		length += 1
 		sliceType.UnsafeGrow(ptr, length)

--- a/reflect_struct_decoder.go
+++ b/reflect_struct_decoder.go
@@ -504,7 +504,7 @@ func (decoder *generalStructDecoder) Decode(ptr unsafe.Pointer, iter *Iterator) 
 		return
 	}
 	var c byte
-	for c = ','; c == ','; c = iter.nextToken() {
+	for c = ','; c == ','; c = iter.NextToken() {
 		decoder.decodeOneField(ptr, iter)
 	}
 	if iter.Error != nil && iter.Error != io.EOF && len(decoder.typ.Type1().Name()) != 0 {
@@ -538,14 +538,14 @@ func (decoder *generalStructDecoder) decodeOneField(ptr unsafe.Pointer, iter *It
 			msg := "found unknown field: " + field
 			iter.ReportError("ReadObject", msg)
 		}
-		c := iter.nextToken()
+		c := iter.NextToken()
 		if c != ':' {
 			iter.ReportError("ReadObject", "expect : after object field, but found "+string([]byte{c}))
 		}
 		iter.Skip()
 		return
 	}
-	c := iter.nextToken()
+	c := iter.NextToken()
 	if c != ':' {
 		iter.ReportError("ReadObject", "expect : after object field, but found "+string([]byte{c}))
 	}
@@ -1075,7 +1075,7 @@ type stringModeNumberDecoder struct {
 }
 
 func (decoder *stringModeNumberDecoder) Decode(ptr unsafe.Pointer, iter *Iterator) {
-	c := iter.nextToken()
+	c := iter.NextToken()
 	if c != '"' {
 		iter.ReportError("stringModeNumberDecoder", `expect ", but found `+string([]byte{c}))
 		return


### PR DESCRIPTION
Required for a custom Unmarshal implementation to check for bytes left after unmarshaling
https://github.com/json-iterator/go/blob/master/config.go#L349

why a custom Unmarshal implementation could be needed ?
since codecs only provide unsafe.Pointer and *Iterator but not the direct value of v that may be needed to avoid reflection cost or just direct handling

thanks !