### PR TITLE
missing capture of error

### DIFF
--- a/any_object.go
+++ b/any_object.go
@@ -68,6 +68,7 @@ func (any *objectLazyAny) ToVal(obj interface{}) {
 	iter := any.cfg.BorrowIterator(any.buf)
 	defer any.cfg.ReturnIterator(iter)
 	iter.ReadVal(obj)
+	any.err = iter.Error
 }
 
 func (any *objectLazyAny) Get(path ...interface{}) Any {


### PR DESCRIPTION
objectLazyAny has an err field (retrieved by LastError()) but isn't used, leading to always no error (nil)