### PR TITLE
Added InputOffset

### DIFF
--- a/adapter.go
+++ b/adapter.go
@@ -95,6 +95,11 @@ func (adapter *Decoder) Buffered() io.Reader {
 	return bytes.NewReader(remaining)
 }
 
+// InputOffset returns current offset in input stream
+func (adapter *Decoder) InputOffset() int64 {
+	return adapter.iter.InputOffset()
+}
+
 // UseNumber causes the Decoder to unmarshal a number into an interface{} as a
 // Number instead of as a float64.
 func (adapter *Decoder) UseNumber() {

--- a/api_tests/decoder_114_test.go
+++ b/api_tests/decoder_114_test.go
@@ -1,0 +1,41 @@
+//+build go1.14
+
+package test
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	jsoniter "github.com/json-iterator/go"
+	"github.com/stretchr/testify/require"
+)
+
+type decoderIfc interface {
+	Decode(obj interface{}) error
+	More() bool
+	InputOffset() int64
+}
+
+func Test_decoder_input_offset(t *testing.T) {
+	should := require.New(t)
+	input := `{"foo" : "bar"}` + "\n" + `{"qoo" : "baz"}`
+	newlinePos := strings.IndexByte(input, '\n')
+
+	runChecks := func(decoder decoderIfc) {
+		should.True(decoder.More())
+		obj := map[string]interface{}{}
+		should.NoError(decoder.Decode(&obj))
+		should.Len(obj, 1)
+		should.True(decoder.More())
+		should.EqualValues(newlinePos+1, decoder.InputOffset())
+		should.NoError(decoder.Decode(&obj))
+		should.EqualValues(len(input), decoder.InputOffset())
+		should.False(decoder.More())
+	}
+
+	// try with stdlib json
+	runChecks(json.NewDecoder(strings.NewReader(input)))
+	// and with jsoniter
+	runChecks(jsoniter.NewDecoder(strings.NewReader(input)))
+}

--- a/api_tests/iter_test.go
+++ b/api_tests/iter_test.go
@@ -1,0 +1,95 @@
+package test
+
+import (
+	"io"
+	"strings"
+	"testing"
+
+	jsoniter "github.com/json-iterator/go"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_iterator_offsets(t *testing.T) {
+	json := `{ "foo": "bar", "num": 123 }
+	{ "num" : 27 }
+	{ "arr": [1.1,2.2,3.3], "obj": { "key": "val"}, "num": 68 }
+	{ "foo.name": "quiz", "num": "321"}`
+
+	should := require.New(t)
+	startOffsets := []int64{}
+	for i, r := range json {
+		if r == '{' {
+			startOffsets = append(startOffsets, int64(i))
+		}
+	}
+	should.Len(startOffsets, 5)
+
+	iter := jsoniter.Parse(jsoniter.ConfigDefault, strings.NewReader(json), 8)
+	should.NotNil(iter)
+
+	should.EqualValues(0, iter.InputOffset())
+	should.Equal(startOffsets[0], iter.InputOffset())
+
+	iter.ReadObjectCB(func(iter *jsoniter.Iterator, key string) bool {
+		switch key {
+		case "foo":
+			should.Equal(jsoniter.StringValue, iter.WhatIsNext())
+			should.EqualValues(9, iter.InputOffset())
+		case "num":
+			should.Equal(jsoniter.NumberValue, iter.WhatIsNext())
+			should.EqualValues(23, iter.InputOffset())
+		default:
+			should.NotNil(nil, "unexpected key: %s", key)
+		}
+
+		// skip the value
+		iter.Skip()
+
+		return true
+	})
+	should.NoError(iter.Error)
+	should.EqualValues(28, iter.InputOffset())
+	should.EqualValues('}', json[iter.InputOffset()-1])
+	// there's still some whitespace to get to the next object
+	should.NotEqual(startOffsets[1], iter.InputOffset())
+
+	// read second line
+
+	should.Equal(jsoniter.ObjectValue, iter.WhatIsNext())
+	should.Equal(startOffsets[1], iter.InputOffset())
+	iter.ReadObjectCB(func(iter *jsoniter.Iterator, key string) bool {
+		switch key {
+		case "num":
+			should.Equal(jsoniter.NumberValue, iter.WhatIsNext())
+			should.EqualValues(40, iter.InputOffset())
+		default:
+			should.NotNil(nil, "unexpected key: %s", key)
+		}
+
+		// skip the value
+		iter.Skip()
+
+		return true
+	})
+	should.NoError(iter.Error)
+
+	// read third line
+	should.Equal(jsoniter.ObjectValue, iter.WhatIsNext())
+	should.Equal(startOffsets[2], iter.InputOffset())
+	for iter.ReadObject() != "" {
+		iter.Skip()
+	}
+	should.NoError(iter.Error)
+
+	// read fourth line
+	should.Equal(jsoniter.ObjectValue, iter.WhatIsNext())
+	should.Equal(startOffsets[4], iter.InputOffset())
+	for iter.ReadObject() != "" {
+		iter.Skip()
+	}
+	should.NoError(iter.Error)
+
+	should.Equal(jsoniter.InvalidValue, iter.WhatIsNext())
+	should.EqualValues(len(json), iter.InputOffset())
+	should.EqualError(iter.Error, io.EOF.Error())
+}


### PR DESCRIPTION
This add InputOffset() to both jsoniter.Decoder as well as Iterator itself, a method which is compatible with InputOffset in stdlib's json.Decoder implementation which got added in go 1.14.