### PR TITLE
added fuzzy decoding for booleans, added ability to decode numeric keyed objects as arrays with fizzy decoder

### DIFF
--- a/extra/fuzzy_decoder_test.go
+++ b/extra/fuzzy_decoder_test.go
@@ -25,6 +25,30 @@ func Test_any_to_string(t *testing.T) {
 	should.NotNil(jsoniter.UnmarshalFromString("{}", &val))
 	should.NotNil(jsoniter.UnmarshalFromString("[]", &val))
 }
+
+func Test_any_to_bool(t *testing.T) {
+	should := require.New(t)
+	var val bool
+	should.Nil(jsoniter.UnmarshalFromString(`"1"`, &val))
+	should.Equal(true, val)
+	should.Nil(jsoniter.UnmarshalFromString(`"true"`, &val))
+	should.Equal(true, val)
+	should.Nil(jsoniter.UnmarshalFromString(`""`, &val))
+	should.Equal(false, val)
+	should.Nil(jsoniter.UnmarshalFromString(`"0"`, &val))
+	should.Equal(false, val)
+	should.Nil(jsoniter.UnmarshalFromString(`"false"`, &val))
+	should.Equal(false, val)
+	should.Nil(jsoniter.UnmarshalFromString("1", &val))
+	should.Equal(true, val)
+	should.Nil(jsoniter.UnmarshalFromString("0", &val))
+	should.Equal(false, val)
+	should.Nil(jsoniter.UnmarshalFromString("null", &val))
+	should.Equal(false, val)
+	should.NotNil(jsoniter.UnmarshalFromString("{}", &val))
+	should.NotNil(jsoniter.UnmarshalFromString("[]", &val))
+}
+
 func Test_any_to_int64(t *testing.T) {
 	should := require.New(t)
 	var val int64
@@ -337,6 +361,24 @@ func Test_empty_array_as_object(t *testing.T) {
 	var val struct{}
 	should.Nil(jsoniter.UnmarshalFromString(`[]`, &val))
 	should.Equal(struct{}{}, val)
+}
+
+func Test_numeric_indexed_object_as_array(t *testing.T) {
+	should := require.New(t)
+	var val [1]string
+	should.Nil(jsoniter.UnmarshalFromString(`{"0":"a","2":"c"}`, &val))
+	should.Equal([1]string{"a"}, val)
+
+	should.Error(jsoniter.UnmarshalFromString(`{"2":"c","0":"a"}`, &val))
+}
+
+func Test_numeric_indexed_object_as_slice(t *testing.T) {
+	should := require.New(t)
+	var val []string
+	should.Nil(jsoniter.UnmarshalFromString(`{"0":"a","2":"c"}`, &val))
+	should.Equal([]string{"a", "c"}, val)
+
+	should.Error(jsoniter.UnmarshalFromString(`{"2":"c","0":"a"}`, &val))
 }
 
 func Test_bad_case(t *testing.T) {


### PR DESCRIPTION
rel https://github.com/json-iterator/go/issues/486

- decode the followings as boolean: `"true"`, `"false"`, `0`, `1`, `"0"`, `"1"`.
- allow unmarshalling numeric keyed objects with strictly increasing keys as array, eg: `{"0": "a", "2": "b"}`

The later is neccessary because of the "unset" php method, eg:

```
<?php

$a = ["a", "b", "c"];
echo json_encode($a); // prints ["a","b","c"]

unset($a[1]);
	
echo json_encode($a); // prints {"0":"a","2":"c"}
```
