### PR TITLE
Fix whitespace-handling bugs in json-iterator decoder

### DIFF
--- a/adapter.go
+++ b/adapter.go
@@ -62,6 +62,7 @@ type Decoder struct {
 
 // Decode decode JSON into interface{}
 func (adapter *Decoder) Decode(obj interface{}) error {
+	adapter.iter.skipWhitespacesWithoutLoadMore()
 	if adapter.iter.head == adapter.iter.tail && adapter.iter.reader != nil {
 		if !adapter.iter.loadMore() {
 			return io.EOF

--- a/iter.go
+++ b/iter.go
@@ -163,6 +163,7 @@ func (iter *Iterator) skipWhitespacesWithoutLoadMore() bool {
 		iter.head = i
 		return false
 	}
+	iter.head = iter.tail
 	return true
 }
 
@@ -274,7 +275,9 @@ func (iter *Iterator) loadMore() bool {
 		} else {
 			iter.head = 0
 			iter.tail = n
-			return true
+			if !iter.skipWhitespacesWithoutLoadMore() {
+				return true
+			}
 		}
 	}
 }


### PR DESCRIPTION
This fixes my unit tests failures.

Note that the existing test suite in `go-iterator` fails at master, without my changes.  Looks like there are related failures in the standard `encoding/json` package, I haven't dug any deeper.

```
$ go test ./...
ok  	github.com/json-iterator/go	5.554s
ok  	github.com/json-iterator/go/any_tests	5.701s
ok  	github.com/json-iterator/go/api_tests	5.300s
ok  	github.com/json-iterator/go/benchmarks	0.694s
ok  	github.com/json-iterator/go/extension_tests	5.161s
ok  	github.com/json-iterator/go/extra	5.805s
ok  	github.com/json-iterator/go/misc_tests	6.473s
ok  	github.com/json-iterator/go/skip_tests	5.566s
--- FAIL: Test_symmetric (0.50s)
    --- FAIL: Test_symmetric/map[test.stringKeyType]string (0.00s)
        type_test.go:55: marshal expected:
                {
                >  "": "{Ħ袴",
                >  "\u003e8ȧ宎軔x宭î\u003e岗Üʎ癮": "%蠂pɨ%y\"憹ʅw",
                >  "A¾員Ç瀍烤ɭĪ銃珚": "璄ę銏C9殝Q橛6駈rD",
                >  "Àɖ\u003c帐埢^¦鯻y睂ƀöɌv滮Ɩř": "Ŧe涴祵#:瓦ƨƼǃ鎠ȼ!囡cg谐綉夻",
                >  "ũɜȃ瘎": "žǺǸ¬%ɯ¹´ǥ",
                >  "ǁ[眧ǩß": "?dǢ煑÷ɒ@索龶ʍ敤骾Ųd5Ƀ緼肐",
                >  "妮ī8羘ɦɍľ": "a\"My罩劇",
                >  "頿Çő": ""
                }
            got:
                {
                >  "MANUAL__": "{Ħ袴",
                >  "MANUAL__\u003e8ȧ宎軔x宭î\u003e岗Üʎ癮": "%蠂pɨ%y\"憹ʅw",
                >  "MANUAL__A¾員Ç瀍烤ɭĪ銃珚": "璄ę銏C9殝Q橛6駈rD",
                >  "MANUAL__Àɖ\u003c帐埢^¦鯻y睂ƀöɌv滮Ɩř": "Ŧe涴祵#:瓦ƨƼǃ鎠ȼ!囡cg谐綉夻",
                >  "MANUAL__ũɜȃ瘎": "žǺǸ¬%ɯ¹´ǥ",
                >  "MANUAL__ǁ[眧ǩß": "?dǢ煑÷ɒ@索龶ʍ敤骾Ųd5Ƀ緼肐",
                >  "MANUAL__妮ī8羘ɦɍľ": "a\"My罩劇",
                >  "MANUAL__頿Çő": ""
                }
            obj:
                (map[test.stringKeyType]string) (len=8) {
            >  (test.stringKeyType) (len=7) "頿Çő": (string) "",
            >  (test.stringKeyType) (len=15) "妮ī8羘ɦɍľ": (string) (len=10) "a\"My罩劇",
            >  (test.stringKeyType) (len=24) "A¾員Ç瀍烤ɭĪ銃珚": (string) (len=23) "璄ę銏C9殝Q橛6駈rD",
            >  (test.stringKeyType) (len=35) "Àɖ<帐埢^¦鯻y睂ƀöɌv滮Ɩř": (string) (len=40) "Ŧe涴祵#:瓦ƨƼǃ鎠ȼ!囡cg谐綉夻",
            >  (test.stringKeyType) (len=27) ">8ȧ宎軔x宭î>岗Üʎ癮": (string) (len=16) "%蠂pɨ%y\"憹ʅw",
            >  (test.stringKeyType) "": (string) (len=6) "{Ħ袴",
            >  (test.stringKeyType) (len=9) "ũɜȃ瘎": (string) (len=17) "žǺǸ¬%ɯ¹´ǥ",
            >  (test.stringKeyType) (len=10) "ǁ[眧ǩß": (string) (len=38) "?dǢ煑÷ɒ@索龶ʍ敤骾Ųd5Ƀ緼肐"
            }
FAIL
FAIL	github.com/json-iterator/go/type_tests	1.507s
ok  	github.com/json-iterator/go/value_tests	5.997s
FAIL
```