### PR TITLE
Iterator: add ability to unescape when reading string as slice

### DIFF
--- a/extra/binary_as_string_codec.go
+++ b/extra/binary_as_string_codec.go
@@ -136,7 +136,7 @@ type binaryAsStringCodec struct {
 }
 
 func (codec *binaryAsStringCodec) Decode(ptr unsafe.Pointer, iter *jsoniter.Iterator) {
-	rawBytes := iter.ReadStringAsSlice()
+	rawBytes := iter.ReadStringAsSlice(true)
 	bytes := make([]byte, 0, len(rawBytes))
 	for i := 0; i < len(rawBytes); i++ {
 		b := rawBytes[i]

--- a/iter_object.go
+++ b/iter_object.go
@@ -236,7 +236,7 @@ func (iter *Iterator) readObjectStart() bool {
 }
 
 func (iter *Iterator) readObjectFieldAsBytes() (ret []byte) {
-	str := iter.ReadStringAsSlice()
+	str := iter.ReadStringAsSlice(true)
 	if iter.skipWhitespacesWithoutLoadMore() {
 		if ret == nil {
 			ret = make([]byte, len(str))

--- a/iter_str.go
+++ b/iter_str.go
@@ -113,17 +113,29 @@ func (iter *Iterator) readEscapedChar(c byte, str []byte) []byte {
 
 // ReadStringAsSlice read string from iterator without copying into string form.
 // The []byte can not be kept, as it will change after next iterator call.
-func (iter *Iterator) ReadStringAsSlice() (ret []byte) {
+func (iter *Iterator) ReadStringAsSlice(alphabetOnly bool) (ret []byte) {
 	c := iter.nextToken()
 	if c == '"' {
 		for i := iter.head; i < iter.tail; i++ {
 			// require ascii string and no escape
 			// for: field name, base64, number
-			if iter.buf[i] == '"' {
+			c := iter.buf[i]
+			if c == '"' {
 				// fast path: reuse the underlying buffer
 				ret = iter.buf[iter.head:i]
 				iter.head = i + 1
 				return ret
+			}
+			if alphabetOnly {
+				continue
+			}
+			if c == '\\' {
+				return iter.readStringAsSliceSlowPath()
+			}
+			if c < ' ' {
+				iter.ReportError("ReadStringAsSlice",
+					fmt.Sprintf(`invalid control character found: %d`, c))
+				return
 			}
 		}
 		readLen := iter.tail - iter.head
@@ -138,8 +150,30 @@ func (iter *Iterator) ReadStringAsSlice() (ret []byte) {
 			copied = append(copied, c)
 		}
 		return copied
+	} else if !alphabetOnly && c == 'n' {
+		iter.skipThreeBytes('u', 'l', 'l')
+		return
 	}
 	iter.ReportError("ReadStringAsSlice", `expects " or n, but found `+string([]byte{c}))
+	return
+}
+
+func (iter *Iterator) readStringAsSliceSlowPath() (ret []byte) {
+	var str []byte
+	var c byte
+	for iter.Error == nil {
+		c = iter.readByte()
+		if c == '"' {
+			return str
+		}
+		if c == '\\' {
+			c = iter.readByte()
+			str = iter.readEscapedChar(c, str)
+		} else {
+			str = append(str, c)
+		}
+	}
+	iter.ReportError("readStringAsSliceSlowPath", "unexpected end of input")
 	return
 }
 

--- a/reflect_struct_decoder.go
+++ b/reflect_struct_decoder.go
@@ -520,7 +520,7 @@ func (decoder *generalStructDecoder) decodeOneField(ptr unsafe.Pointer, iter *It
 	var field string
 	var fieldDecoder *structFieldDecoder
 	if iter.cfg.objectFieldMustBeSimpleString {
-		fieldBytes := iter.ReadStringAsSlice()
+		fieldBytes := iter.ReadStringAsSlice(true)
 		field = *(*string)(unsafe.Pointer(&fieldBytes))
 		fieldDecoder = decoder.fields[field]
 		if fieldDecoder == nil && !iter.cfg.caseSensitive {


### PR DESCRIPTION
For an application like OpenRTB, where memory reuse is important, the `ReadStringAsSlice` comes in handy. But, unfortunately, it does not unescape strings and it doesn't have check for null as `ReadString` #537