### PR TITLE
Fix incorrect indention marshaling map/object

### DIFF
--- a/api_tests/marshal_indent_test.go
+++ b/api_tests/marshal_indent_test.go
@@ -2,35 +2,113 @@ package test
 
 import (
 	"encoding/json"
-	"github.com/json-iterator/go"
-	"github.com/stretchr/testify/require"
 	"testing"
+
+	jsoniter "github.com/json-iterator/go"
+	"github.com/stretchr/testify/require"
 )
 
 func Test_marshal_indent(t *testing.T) {
-	should := require.New(t)
-	obj := struct {
-		F1 int
-		F2 []int
-	}{1, []int{2, 3, 4}}
-	output, err := json.MarshalIndent(obj, "", "  ")
-	should.Nil(err)
-	should.Equal("{\n  \"F1\": 1,\n  \"F2\": [\n    2,\n    3,\n    4\n  ]\n}", string(output))
-	output, err = jsoniter.MarshalIndent(obj, "", "  ")
-	should.Nil(err)
-	should.Equal("{\n  \"F1\": 1,\n  \"F2\": [\n    2,\n    3,\n    4\n  ]\n}", string(output))
+	testcases := []struct {
+		name   string
+		obj    interface{}
+		expect string
+	}{
+		{
+			name: "no writable fields",
+			obj: struct {
+				Writable   bool `json:"writable,omitempty"`
+				unexported int
+			}{Writable: false, unexported: 1},
+			expect: "{}",
+		},
+		{
+			name: "flattened fields",
+			obj: struct {
+				F1 int
+				F2 []int
+			}{F1: 1, F2: []int{2, 3, 4}},
+			expect: "{\n  \"F1\": 1,\n  \"F2\": [\n    2,\n    3,\n    4\n  ]\n}",
+		},
+		{
+			name: "nested fields",
+			obj: struct {
+				F1 map[int]int
+				F2 struct{ V int }
+			}{F1: map[int]int{1: 1}, F2: struct{ V int }{V: 2}},
+			expect: "{\n  \"F1\": {\n    \"1\": 1\n  },\n  \"F2\": {\n    \"V\": 2\n  }\n}",
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			should := require.New(t)
+			obj := tc.obj
+
+			output, err := json.MarshalIndent(obj, "", "  ")
+			should.Nil(err)
+			should.Equal(tc.expect, string(output))
+
+			output, err = jsoniter.MarshalIndent(obj, "", "  ")
+			should.Nil(err)
+			should.Equal(tc.expect, string(output))
+
+			output, err = jsoniter.ConfigCompatibleWithStandardLibrary.MarshalIndent(obj, "", "  ")
+			should.Nil(err)
+			should.Equal(tc.expect, string(output))
+		})
+	}
 }
 
 func Test_marshal_indent_map(t *testing.T) {
-	should := require.New(t)
-	obj := map[int]int{1: 2}
-	output, err := json.MarshalIndent(obj, "", "  ")
-	should.Nil(err)
-	should.Equal("{\n  \"1\": 2\n}", string(output))
-	output, err = jsoniter.MarshalIndent(obj, "", "  ")
-	should.Nil(err)
-	should.Equal("{\n  \"1\": 2\n}", string(output))
-	output, err = jsoniter.ConfigCompatibleWithStandardLibrary.MarshalIndent(obj, "", "  ")
-	should.Nil(err)
-	should.Equal("{\n  \"1\": 2\n}", string(output))
+	testcases := []struct {
+		name   string
+		obj    interface{}
+		expect string
+	}{
+		{
+			name:   "empty map",
+			obj:    map[int]int{},
+			expect: "{}",
+		},
+		{
+			name:   "map with literal value",
+			obj:    map[int]int{1: 2},
+			expect: "{\n  \"1\": 2\n}",
+		},
+		{
+			name:   "map with array value",
+			obj:    map[int][]int{1: {1, 2}},
+			expect: "{\n  \"1\": [\n    1,\n    2\n  ]\n}",
+		},
+		{
+			name:   "map with nested map",
+			obj:    map[int]map[int]int{1: {1: 2}},
+			expect: "{\n  \"1\": {\n    \"1\": 2\n  }\n}",
+		},
+		{
+			name:   "map with object value",
+			obj:    map[int]struct{ F int }{1: {F: 2}},
+			expect: "{\n  \"1\": {\n    \"F\": 2\n  }\n}",
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			should := require.New(t)
+			obj := tc.obj
+
+			output, err := json.MarshalIndent(obj, "", "  ")
+			should.Nil(err)
+			should.Equal(tc.expect, string(output))
+
+			output, err = jsoniter.MarshalIndent(obj, "", "  ")
+			should.Nil(err)
+			should.Equal(tc.expect, string(output))
+
+			output, err = jsoniter.ConfigCompatibleWithStandardLibrary.MarshalIndent(obj, "", "  ")
+			should.Nil(err)
+			should.Equal(tc.expect, string(output))
+		})
+	}
 }

--- a/misc_tests/jsoniter_object_test.go
+++ b/misc_tests/jsoniter_object_test.go
@@ -3,12 +3,12 @@ package misc_tests
 import (
 	"bytes"
 	"reflect"
-	"testing"
-
-	"github.com/json-iterator/go"
-	"github.com/stretchr/testify/require"
 	"strings"
+	"testing"
 	"time"
+
+	jsoniter "github.com/json-iterator/go"
+	"github.com/stretchr/testify/require"
 )
 
 func Test_empty_object(t *testing.T) {

--- a/reflect_map.go
+++ b/reflect_map.go
@@ -2,11 +2,12 @@ package jsoniter
 
 import (
 	"fmt"
-	"github.com/modern-go/reflect2"
 	"io"
 	"reflect"
 	"sort"
 	"unsafe"
+
+	"github.com/modern-go/reflect2"
 )
 
 func decoderOfMap(ctx *ctx, typ reflect2.Type) ValDecoder {
@@ -290,6 +291,7 @@ func (encoder *sortKeysMapEncoder) Encode(ptr unsafe.Pointer, stream *Stream) {
 	stream.WriteObjectStart()
 	mapIter := encoder.mapType.UnsafeIterate(ptr)
 	subStream := stream.cfg.BorrowStream(nil)
+	subStream.SetIndention(stream.indention)
 	subStream.Attachment = stream.Attachment
 	subIter := stream.cfg.BorrowIterator(nil)
 	keyValues := encodedKeyValues{}

--- a/reflect_struct_encoder.go
+++ b/reflect_struct_encoder.go
@@ -2,10 +2,11 @@ package jsoniter
 
 import (
 	"fmt"
-	"github.com/modern-go/reflect2"
 	"io"
 	"reflect"
 	"unsafe"
+
+	"github.com/modern-go/reflect2"
 )
 
 func encoderOfStruct(ctx *ctx, typ reflect2.Type) ValEncoder {

--- a/stream.go
+++ b/stream.go
@@ -37,12 +37,18 @@ func (stream *Stream) Pool() StreamPool {
 // Reset reuse this stream instance by assign a new writer
 func (stream *Stream) Reset(out io.Writer) {
 	stream.out = out
+	stream.indention = 0
 	stream.buf = stream.buf[:0]
 }
 
 // Available returns how many bytes are unused in the buffer.
 func (stream *Stream) Available() int {
 	return cap(stream.buf) - len(stream.buf)
+}
+
+// SetIndention init indention before being used.
+func (stream *Stream) SetIndention(i int) {
+	stream.indention = i
 }
 
 // Buffered returns the number of bytes that have been written into the current buffer.
@@ -162,7 +168,9 @@ func (stream *Stream) WriteObjectField(field string) {
 
 // WriteObjectEnd write } with possible indention
 func (stream *Stream) WriteObjectEnd() {
-	stream.writeIndention(stream.cfg.indentionStep)
+	if !stream.revertObjectStartIndention() {
+		stream.writeIndention(stream.cfg.indentionStep)
+	}
 	stream.indention -= stream.cfg.indentionStep
 	stream.writeByte('}')
 }
@@ -207,4 +215,20 @@ func (stream *Stream) writeIndention(delta int) {
 	for i := 0; i < toWrite; i++ {
 		stream.buf = append(stream.buf, ' ')
 	}
+}
+
+// revertObjectStartIndention reverts the redundantly introduced indention when
+//  writing object start if there are no writable fields.
+func (stream *Stream) revertObjectStartIndention() (reverted bool) {
+	if stream.indention == 0 {
+		return false
+	}
+	// No writes after object start if the last byte is an indention character.
+	lastBytePos := stream.Buffered() - 1
+	if lastBytePos >= 0 && stream.buf[lastBytePos] == ' ' {
+		revertedLen := stream.Buffered() - 1 - stream.indention
+		stream.buf = stream.buf[:revertedLen]
+		return true
+	}
+	return false
 }


### PR DESCRIPTION
Fix issue [#564](https://github.com/json-iterator/go/issues/564) .

1. Substream in `sortKeysMapEncoder` inherits indention from parent.
2. Revert extra newline&indention for obj with no writable fields.
3. Add more test cases for `MarshalIndent` API.