### PR TITLE
Make RawMessage an alias of json.RawMessage

### DIFF
--- a/adapter.go
+++ b/adapter.go
@@ -2,11 +2,12 @@ package jsoniter
 
 import (
 	"bytes"
+	"encoding/json"
 	"io"
 )
 
 // RawMessage to make replace json with jsoniter
-type RawMessage []byte
+type RawMessage = json.RawMessage
 
 // Unmarshal adapts to json/encoding Unmarshal API
 //

--- a/config.go
+++ b/config.go
@@ -194,7 +194,6 @@ func (cfg *frozenConfig) validateJsonRawMessage(extension EncoderExtension) {
 		return len(*((*json.RawMessage)(ptr))) == 0
 	}}
 	extension[reflect2.TypeOfPtr((*json.RawMessage)(nil)).Elem()] = encoder
-	extension[reflect2.TypeOfPtr((*RawMessage)(nil)).Elem()] = encoder
 }
 
 func (cfg *frozenConfig) useNumber(extension DecoderExtension) {

--- a/misc_tests/jsoniter_raw_message_test.go
+++ b/misc_tests/jsoniter_raw_message_test.go
@@ -10,7 +10,7 @@ import (
 
 func Test_jsoniter_RawMessage(t *testing.T) {
 	should := require.New(t)
-	var data jsoniter.RawMessage
+	var data json.RawMessage
 	should.Nil(jsoniter.Unmarshal([]byte(`[1,2,3]`), &data))
 	should.Equal(`[1,2,3]`, string(data))
 	str, err := jsoniter.MarshalToString(data)
@@ -20,8 +20,8 @@ func Test_jsoniter_RawMessage(t *testing.T) {
 
 func Test_encode_map_of_jsoniter_raw_message(t *testing.T) {
 	should := require.New(t)
-	type RawMap map[string]*jsoniter.RawMessage
-	value := jsoniter.RawMessage("[]")
+	type RawMap map[string]*json.RawMessage
+	value := json.RawMessage("[]")
 	rawMap := RawMap{"hello": &value}
 	output, err := jsoniter.MarshalToString(rawMap)
 	should.Nil(err)
@@ -44,7 +44,7 @@ func Test_marshal_invalid_json_raw_message(t *testing.T) {
 
 func Test_marshal_nil_json_raw_message(t *testing.T) {
 	type A struct {
-		Nil1 jsoniter.RawMessage `json:"raw1"`
+		Nil1 json.RawMessage `json:"raw1"`
 		Nil2 json.RawMessage     `json:"raw2"`
 	}
 
@@ -72,9 +72,9 @@ func Test_raw_message_memory_not_copied_issue(t *testing.T) {
 		BiddingMax  *float32             `json:"bidding_max"`
 		BiddingMin  *float32             `json:"bidding_min"`
 		BiddingType *string              `json:"bidding_type"`
-		Freq        *jsoniter.RawMessage `json:"freq"`
-		Targeting   *jsoniter.RawMessage `json:"targeting"`
-		Url         *jsoniter.RawMessage `json:"url"`
+		Freq        *json.RawMessage `json:"freq"`
+		Targeting   *json.RawMessage `json:"targeting"`
+		Url         *json.RawMessage `json:"url"`
 		Speed       *int                 `json:"speed" db:"speed"`
 	}
 

--- a/reflect_json_raw_message.go
+++ b/reflect_json_raw_message.go
@@ -7,14 +7,10 @@ import (
 )
 
 var jsonRawMessageType = reflect2.TypeOfPtr((*json.RawMessage)(nil)).Elem()
-var jsoniterRawMessageType = reflect2.TypeOfPtr((*RawMessage)(nil)).Elem()
 
 func createEncoderOfJsonRawMessage(ctx *ctx, typ reflect2.Type) ValEncoder {
 	if typ == jsonRawMessageType {
 		return &jsonRawMessageCodec{}
-	}
-	if typ == jsoniterRawMessageType {
-		return &jsoniterRawMessageCodec{}
 	}
 	return nil
 }
@@ -22,9 +18,6 @@ func createEncoderOfJsonRawMessage(ctx *ctx, typ reflect2.Type) ValEncoder {
 func createDecoderOfJsonRawMessage(ctx *ctx, typ reflect2.Type) ValDecoder {
 	if typ == jsonRawMessageType {
 		return &jsonRawMessageCodec{}
-	}
-	if typ == jsoniterRawMessageType {
-		return &jsoniterRawMessageCodec{}
 	}
 	return nil
 }
@@ -50,27 +43,4 @@ func (codec *jsonRawMessageCodec) Encode(ptr unsafe.Pointer, stream *Stream) {
 
 func (codec *jsonRawMessageCodec) IsEmpty(ptr unsafe.Pointer) bool {
 	return len(*((*json.RawMessage)(ptr))) == 0
-}
-
-type jsoniterRawMessageCodec struct {
-}
-
-func (codec *jsoniterRawMessageCodec) Decode(ptr unsafe.Pointer, iter *Iterator) {
-	if iter.ReadNil() {
-		*((*RawMessage)(ptr)) = nil
-	} else {
-		*((*RawMessage)(ptr)) = iter.SkipAndReturnBytes()
-	}
-}
-
-func (codec *jsoniterRawMessageCodec) Encode(ptr unsafe.Pointer, stream *Stream) {
-	if *((*RawMessage)(ptr)) == nil {
-		stream.WriteNil()
-	} else {
-		stream.WriteRaw(string(*((*RawMessage)(ptr))))
-	}
-}
-
-func (codec *jsoniterRawMessageCodec) IsEmpty(ptr unsafe.Pointer) bool {
-	return len(*((*RawMessage)(ptr))) == 0
 }


### PR DESCRIPTION
Instead of introducing a custom `RawMessage` type that simply wraps a `[]byte` and has no methods, make `jsoniter.RawMessage` an alias of `json.RawMessage`, thereby increasing compatibility when replacing `encoding/json`.