### PR TITLE
all: remove unnecessary string([]byte) conversion in fmt.Sprintf yet %s

### DIFF
--- a/iter_object.go
+++ b/iter_object.go
@@ -40,7 +40,7 @@ func (iter *Iterator) ReadObject() (ret string) {
 	case '}':
 		return "" // end of object
 	default:
-		iter.ReportError("ReadObject", fmt.Sprintf(`expect { or , or } or n, but found %s`, string([]byte{c})))
+		iter.ReportError("ReadObject", fmt.Sprintf(`expect { or , or } or n, but found %c`, c))
 		return
 	}
 }

--- a/iter_skip.go
+++ b/iter_skip.go
@@ -97,34 +97,34 @@ func (iter *Iterator) Skip() {
 
 func (iter *Iterator) skipFourBytes(b1, b2, b3, b4 byte) {
 	if iter.readByte() != b1 {
-		iter.ReportError("skipFourBytes", fmt.Sprintf("expect %s", string([]byte{b1, b2, b3, b4})))
+		iter.ReportError("skipFourBytes", fmt.Sprintf("expect %s", []byte{b1, b2, b3, b4}))
 		return
 	}
 	if iter.readByte() != b2 {
-		iter.ReportError("skipFourBytes", fmt.Sprintf("expect %s", string([]byte{b1, b2, b3, b4})))
+		iter.ReportError("skipFourBytes", fmt.Sprintf("expect %s", []byte{b1, b2, b3, b4}))
 		return
 	}
 	if iter.readByte() != b3 {
-		iter.ReportError("skipFourBytes", fmt.Sprintf("expect %s", string([]byte{b1, b2, b3, b4})))
+		iter.ReportError("skipFourBytes", fmt.Sprintf("expect %s", []byte{b1, b2, b3, b4}))
 		return
 	}
 	if iter.readByte() != b4 {
-		iter.ReportError("skipFourBytes", fmt.Sprintf("expect %s", string([]byte{b1, b2, b3, b4})))
+		iter.ReportError("skipFourBytes", fmt.Sprintf("expect %s", []byte{b1, b2, b3, b4}))
 		return
 	}
 }
 
 func (iter *Iterator) skipThreeBytes(b1, b2, b3 byte) {
 	if iter.readByte() != b1 {
-		iter.ReportError("skipThreeBytes", fmt.Sprintf("expect %s", string([]byte{b1, b2, b3})))
+		iter.ReportError("skipThreeBytes", fmt.Sprintf("expect %s", []byte{b1, b2, b3}))
 		return
 	}
 	if iter.readByte() != b2 {
-		iter.ReportError("skipThreeBytes", fmt.Sprintf("expect %s", string([]byte{b1, b2, b3})))
+		iter.ReportError("skipThreeBytes", fmt.Sprintf("expect %s", []byte{b1, b2, b3}))
 		return
 	}
 	if iter.readByte() != b3 {
-		iter.ReportError("skipThreeBytes", fmt.Sprintf("expect %s", string([]byte{b1, b2, b3})))
+		iter.ReportError("skipThreeBytes", fmt.Sprintf("expect %s", []byte{b1, b2, b3}))
 		return
 	}
 }


### PR DESCRIPTION
Noticed from Orijtech's continuous benchmarking product "Bencher" per

https://dashboard.github.orijtech.com/benchmark/3245b8e4bbbd44a597480319aaa4b9fe

that there is a bunch of code in the wild that invokes:

    fmt.Sprintf("%s", string([]byte(...)))

yet the "%s" format specifier in fmt has a purpose:

    %s	the uninterpreted bytes of the string or slice

We can improve and reduce allocations simply by invoking

    fmt.Sprintf("%s", []byte(...))

which led to big improvements across every dimension:
* CPU time reduction by 11+% (ns/op)
* throughput improvement by 13+% (MBs/op)
* allocations reduction by 45+% (B/op)
* number of allocations reduction by 18+% (alloc/op)

/cc @kirbyquerby @willpoint