### PR TITLE
Unmarshalling float with lots of digits can cause >= 2 allocations per number

### DIFF
--- a/benchmarks/float_test.go
+++ b/benchmarks/float_test.go
@@ -1,0 +1,28 @@
+package test
+
+import (
+	"testing"
+
+	jsoniter "github.com/json-iterator/go"
+)
+
+func BenchmarkFloatUnmarshal(b *testing.B) {
+	type floaty struct {
+		A float32
+		B float64
+	}
+
+	data, err := jsoniter.Marshal(floaty{A: 1.111111111111111, B: 1.11111111111111})
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	var out floaty
+	for i := 0; i < b.N; i++ {
+		if err := jsoniter.Unmarshal(data, &out); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/benchmarks/stream_test.go
+++ b/benchmarks/stream_test.go
@@ -10,7 +10,8 @@ import (
 
 func Benchmark_stream_encode_big_object(b *testing.B) {
 	var buf bytes.Buffer
-	var stream = jsoniter.NewStream(jsoniter.ConfigDefault, &buf, 100)
+	stream := jsoniter.NewStream(jsoniter.ConfigDefault, &buf, 100)
+	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
 		buf.Reset()
 		stream.Reset(&buf)
@@ -22,13 +23,13 @@ func Benchmark_stream_encode_big_object(b *testing.B) {
 }
 
 func TestEncodeObject(t *testing.T) {
-	var stream = jsoniter.NewStream(jsoniter.ConfigDefault, nil, 100)
+	stream := jsoniter.NewStream(jsoniter.ConfigDefault, nil, 100)
 	encodeObject(stream)
 	if stream.Error != nil {
 		t.Errorf("error encoding a test object: %+v", stream.Error)
 		return
 	}
-	var m = make(map[string]interface{})
+	m := make(map[string]interface{})
 	if err := jsoniter.Unmarshal(stream.Buffer(), &m); err != nil {
 		t.Errorf("error unmarshaling a test object: %+v", err)
 		return

--- a/iter.go
+++ b/iter.go
@@ -26,8 +26,10 @@ const (
 	ObjectValue
 )
 
-var hexDigits []byte
-var valueTypes []ValueType
+var (
+	hexDigits  []byte
+	valueTypes []ValueType
+)
 
 func init() {
 	hexDigits = make([]byte, 256)
@@ -78,6 +80,7 @@ type Iterator struct {
 	captureStartedAt int
 	captured         []byte
 	Error            error
+	scratch          []byte
 	Attachment       interface{} // open for customized decoder
 }
 


### PR DESCRIPTION
We can fix this with a little bit of scratch space.