### PR TITLE
fix MarshalIndent when use SortMapKeys

### DIFF
--- a/api_tests/marshal_indent_test.go
+++ b/api_tests/marshal_indent_test.go
@@ -34,3 +34,14 @@ func Test_marshal_indent_map(t *testing.T) {
 	should.Nil(err)
 	should.Equal("{\n  \"1\": 2\n}", string(output))
 }
+
+func Test_marshal_indent_nested_sorted(t *testing.T) {
+	should := require.New(t)
+	obj := map[int]interface{}{
+		1: map[int]int{2: 3},
+	}
+	ji := jsoniter.Config{SortMapKeys: true}.Froze()
+	output, err := ji.MarshalIndent(obj, "", "  ")
+	should.Nil(err)
+	should.Equal("{\n  \"1\": {\n    \"2\": 3\n  }\n}", string(output))
+}

--- a/pool.go
+++ b/pool.go
@@ -26,6 +26,7 @@ func (cfg *frozenConfig) ReturnStream(stream *Stream) {
 	stream.out = nil
 	stream.Error = nil
 	stream.Attachment = nil
+	stream.indention = 0
 	cfg.streamPool.Put(stream)
 }
 

--- a/reflect_map.go
+++ b/reflect_map.go
@@ -291,6 +291,7 @@ func (encoder *sortKeysMapEncoder) Encode(ptr unsafe.Pointer, stream *Stream) {
 	mapIter := encoder.mapType.UnsafeIterate(ptr)
 	subStream := stream.cfg.BorrowStream(nil)
 	subStream.Attachment = stream.Attachment
+	subStream.indention = stream.indention
 	subIter := stream.cfg.BorrowIterator(nil)
 	keyValues := encodedKeyValues{}
 	for mapIter.HasNext() {


### PR DESCRIPTION
subStream fork not inherit indention field, may be this place has a same bug...

https://github.com/json-iterator/go/blob/024077e996b048517130b21ea6bf12aa23055d3d/reflect_struct_encoder.go#L201-L207