### PR TITLE
Clean up zero for float encoder and make compatible with std

### DIFF
--- a/stream_float.go
+++ b/stream_float.go
@@ -12,6 +12,18 @@ func init() {
 	pow10 = []uint64{1, 10, 100, 1000, 10000, 100000, 1000000}
 }
 
+func (stream *Stream) cleanupZero(b []byte, fmt byte) []byte {
+	if fmt == 'e' {
+		// clean up e-09 to e-9
+		n := len(b)
+		if n >= 4 && b[n-4] == 'e' && b[n-3] == '-' && b[n-2] == '0' {
+			b[n-2] = b[n-1]
+			b = b[:n-1]
+		}
+	}
+	return b
+}
+
 // WriteFloat32 write float32 to stream
 func (stream *Stream) WriteFloat32(val float32) {
 	if math.IsInf(float64(val), 0) || math.IsNaN(float64(val)) {
@@ -27,6 +39,7 @@ func (stream *Stream) WriteFloat32(val float32) {
 		}
 	}
 	stream.buf = strconv.AppendFloat(stream.buf, float64(val), fmt, -1, 32)
+	stream.buf = stream.cleanupZero(stream.buf, fmt)
 }
 
 // WriteFloat32Lossy write float32 to stream with ONLY 6 digits precision although much much faster
@@ -76,6 +89,7 @@ func (stream *Stream) WriteFloat64(val float64) {
 		}
 	}
 	stream.buf = strconv.AppendFloat(stream.buf, float64(val), fmt, -1, 64)
+	stream.buf = stream.cleanupZero(stream.buf, fmt)
 }
 
 // WriteFloat64Lossy write float64 to stream with ONLY 6 digits precision although much much faster

--- a/value_tests/float_test.go
+++ b/value_tests/float_test.go
@@ -4,10 +4,11 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"github.com/json-iterator/go"
-	"github.com/stretchr/testify/require"
 	"strconv"
 	"testing"
+
+	jsoniter "github.com/json-iterator/go"
+	"github.com/stretchr/testify/require"
 )
 
 func Test_read_float(t *testing.T) {
@@ -86,9 +87,13 @@ func Test_write_float32(t *testing.T) {
 	should.Nil(stream.Error)
 	should.Equal("abcdefg1.123456", buf.String())
 
+	val := float32(0.0000001)
 	stream = jsoniter.NewStream(jsoniter.ConfigDefault, nil, 0)
-	stream.WriteFloat32(float32(0.0000001))
-	should.Equal("1e-07", string(stream.Buffer()))
+	stream.WriteFloat32(val)
+	output, err := json.Marshal(val)
+	should.Nil(err)
+	should.Equal("1e-7", string(stream.Buffer()))
+	should.Equal(string(output), string(stream.Buffer()))
 }
 
 func Test_write_float64(t *testing.T) {
@@ -123,7 +128,11 @@ func Test_write_float64(t *testing.T) {
 	should.Nil(stream.Error)
 	should.Equal("abcdefg1.123456", buf.String())
 
+	val := float64(0.0000001)
 	stream = jsoniter.NewStream(jsoniter.ConfigDefault, nil, 0)
-	stream.WriteFloat64(float64(0.0000001))
-	should.Equal("1e-07", string(stream.Buffer()))
+	stream.WriteFloat64(val)
+	output, err := json.Marshal(val)
+	should.Nil(err)
+	should.Equal("1e-7", string(stream.Buffer()))
+	should.Equal(string(output), string(stream.Buffer()))
 }


### PR DESCRIPTION
Clean up zero and convert float as if by ES6 number to string conversion:
- Clean up example: `e-09` to `e-9`
- More detailed reference [std floatEncoder](https://cs.opensource.google/go/go/+/master:src/encoding/json/encode.go;l=574?q=encode.go&ss=go%2Fgo)