### PR TITLE
fix frozeWithCacheReuse

### DIFF
--- a/adapter.go
+++ b/adapter.go
@@ -100,7 +100,7 @@ func (adapter *Decoder) Buffered() io.Reader {
 func (adapter *Decoder) UseNumber() {
 	cfg := adapter.iter.cfg.configBeforeFrozen
 	cfg.UseNumber = true
-	adapter.iter.cfg = cfg.frozeWithCacheReuse(adapter.iter.cfg.extraExtensions)
+	adapter.iter.cfg = cfg.frozeWithCacheReuse(adapter.iter.cfg)
 }
 
 // DisallowUnknownFields causes the Decoder to return an error when the destination
@@ -109,7 +109,7 @@ func (adapter *Decoder) UseNumber() {
 func (adapter *Decoder) DisallowUnknownFields() {
 	cfg := adapter.iter.cfg.configBeforeFrozen
 	cfg.DisallowUnknownFields = true
-	adapter.iter.cfg = cfg.frozeWithCacheReuse(adapter.iter.cfg.extraExtensions)
+	adapter.iter.cfg = cfg.frozeWithCacheReuse(adapter.iter.cfg)
 }
 
 // NewEncoder same as json.NewEncoder
@@ -134,14 +134,14 @@ func (adapter *Encoder) Encode(val interface{}) error {
 func (adapter *Encoder) SetIndent(prefix, indent string) {
 	config := adapter.stream.cfg.configBeforeFrozen
 	config.IndentionStep = len(indent)
-	adapter.stream.cfg = config.frozeWithCacheReuse(adapter.stream.cfg.extraExtensions)
+	adapter.stream.cfg = config.frozeWithCacheReuse(adapter.stream.cfg)
 }
 
 // SetEscapeHTML escape html by default, set to false to disable
 func (adapter *Encoder) SetEscapeHTML(escapeHTML bool) {
 	config := adapter.stream.cfg.configBeforeFrozen
 	config.EscapeHTML = escapeHTML
-	adapter.stream.cfg = config.frozeWithCacheReuse(adapter.stream.cfg.extraExtensions)
+	adapter.stream.cfg = config.frozeWithCacheReuse(adapter.stream.cfg)
 }
 
 // Valid reports whether data is a valid JSON encoding.

--- a/config.go
+++ b/config.go
@@ -113,7 +113,12 @@ func (cfg *frozenConfig) getEncoderFromCache(cacheKey uintptr) ValEncoder {
 
 var cfgCache = concurrent.NewMap()
 
-func getFrozenConfigFromCache(key interface{}) *frozenConfig {
+type cfgKey struct {
+	Config
+	cause *frozenConfig
+}
+
+func getFrozenConfigFromCache(key cfgKey) *frozenConfig {
 	obj, found := cfgCache.Load(key)
 	if found {
 		return obj.(*frozenConfig)
@@ -121,7 +126,7 @@ func getFrozenConfigFromCache(key interface{}) *frozenConfig {
 	return nil
 }
 
-func addFrozenConfigToCache(key interface{}, frozenConfig *frozenConfig) {
+func addFrozenConfigToCache(key cfgKey, frozenConfig *frozenConfig) {
 	cfgCache.Store(key, frozenConfig)
 }
 
@@ -166,13 +171,8 @@ func (cfg Config) Froze() API {
 	return api
 }
 
-type configKey struct {
-	Config
-	cause *frozenConfig
-}
-
 func (cfg Config) frozeWithCacheReuse(cause *frozenConfig) *frozenConfig {
-	key := configKey{cfg, cause}
+	key := cfgKey{cfg, cause}
 	api := getFrozenConfigFromCache(key)
 	if api != nil {
 		return api

--- a/extension_tests/extension_test.go
+++ b/extension_tests/extension_test.go
@@ -1,13 +1,14 @@
 package test
 
 import (
-	"github.com/json-iterator/go"
-	"github.com/modern-go/reflect2"
-	"github.com/stretchr/testify/require"
 	"reflect"
 	"strconv"
 	"testing"
 	"unsafe"
+
+	jsoniter "github.com/json-iterator/go"
+	"github.com/modern-go/reflect2"
+	"github.com/stretchr/testify/require"
 )
 
 type TestObject1 struct {
@@ -59,6 +60,19 @@ func Test_customize_map_key_encoder(t *testing.T) {
 	m = map[int]int{}
 	should.NoError(cfg.UnmarshalFromString(output, &m))
 	should.Equal(map[int]int{1: 2}, m)
+
+	b, err := cfg.MarshalIndent(m, "", "  ")
+	should.NoError(err)
+	should.Equal(`{
+  "2": 2
+}`, string(b))
+
+	cfg = jsoniter.Config{}.Froze() // without testMapKeyExtension
+	b, err = cfg.MarshalIndent(m, "", "  ")
+	should.NoError(err)
+	should.Equal(`{
+  "1": 2
+}`, string(b))
 }
 
 type testMapKeyExtension struct {


### PR DESCRIPTION
```
func Test_customize_map_key_encoder(t *testing.T) {
	should := require.New(t)
	cfg := jsoniter.Config{}.Froze()
	cfg.RegisterExtension(&testMapKeyExtension{})
	m := map[int]int{1: 2}

	b, err := cfg.MarshalIndent(m, "", "  ")
	should.NoError(err)
	should.Equal(`{
  "2": 2
}`, string(b))

	cfg = jsoniter.Config{}.Froze() // without testMapKeyExtension
	b, err = cfg.MarshalIndent(m, "", "  ")
	should.NoError(err)
// !!!!! Before fix, it won't be equal here !!!!!!!
	should.Equal(`{
  "1": 2
}`, string(b))
}
```