### PR TITLE
Fix #657 incorrect encoding of embedded-recursive types and overlapping tags

### DIFF
--- a/type_tests/struct_embedded_test.go
+++ b/type_tests/struct_embedded_test.go
@@ -61,6 +61,9 @@ func init() {
 		(*SameLevel2Tagged)(nil),
 		(*EmbeddedPtr)(nil),
 		(*UnnamedLiteral)(nil),
+		(*EmbeddedRecursive)(nil),
+		(*EmbeddedRecursive2)(nil),
+		(*EmbeddedRecursive3)(nil),
 	)
 }
 
@@ -235,4 +238,43 @@ type EmbeddedPtr struct {
 
 type UnnamedLiteral struct {
 	_ struct{}
+}
+
+type EmbeddedRecursive struct {
+	Foo string
+	Recursive1
+}
+
+type Recursive1 struct {
+	R string
+	Recursive2
+}
+
+type Recursive2 struct {
+	Foo string
+	R   string
+	RR  string
+	*EmbeddedRecursive
+}
+
+type EmbeddedRecursive2 struct {
+	Foo string
+	Recursive1
+	Recursive3
+}
+
+type Recursive3 struct {
+	Foo string
+	RR  string
+	*EmbeddedRecursive2
+}
+
+type Recursive4 struct {
+	Bar string
+	Recursive3
+}
+
+type EmbeddedRecursive3 struct {
+	Foo string
+	*EmbeddedRecursive3
 }

--- a/type_tests/struct_tags_test.go
+++ b/type_tests/struct_tags_test.go
@@ -149,6 +149,32 @@ func init() {
 		(*struct {
 			Field bool `json:"中文"`
 		})(nil),
+		(*struct {
+			Foo string `json:"Bar"`
+			Bar string
+		})(nil),
+		(*struct {
+			Foo string `json:"Bar"`
+			Bar string `json:"Foo"`
+		})(nil),
+		(*struct {
+			Foo string
+			Bar string `json:"Foo"`
+		})(nil),
+		(*struct {
+			Foo string `json:"Bar"`
+			Bar string `json:"Bar"`
+		})(nil),
+		(*struct {
+			Foo string `json:"Bar"`
+			Bar string
+			Baz string `json:"Bar"`
+		})(nil),
+		(*struct {
+			Foo string
+			F   string
+			EmbeddedOmitEmptyE
+		})(nil),
 	)
 }
 


### PR DESCRIPTION
Just to explore how to fix #657 .

A simple fix to recursive embedded types is to add recursion check.
This, however, breaks other test cases.

I found that it is hard to fix the problem by changing the current `resolveConflictBinding` implementation, because it does it without field information, while Go's `dominantField` does it with field info.
Adding the overlapping-field-resolver implementation almost identical to that of the std's `encoding/json`, of course, fixes the problem.

This PR introduces significant changes to the code base (at least it's not like 50 lines fix).
So this might not be suitable for the goal of this library.