### PR TITLE
Fix `,string` option applying to non applicable value / types

### DIFF
--- a/type_tests/struct_tags_test.go
+++ b/type_tests/struct_tags_test.go
@@ -147,6 +147,28 @@ func init() {
 			Field bool `json:",omitempty,string"`
 		})(nil),
 		(*struct {
+			Str  *string  `json:",string"`
+			F32  *float32 `json:",string"`
+			F64  *float64 `json:",string"`
+			Int  *int     `json:",string"`
+			Uint *uint    `json:",string"`
+			I16  *int16   `json:",string"`
+			I32  *int32   `json:",string"`
+			I64  *int64   `json:",string"`
+			U8   *uint8   `json:",string"`
+			U16  *uint16  `json:",string"`
+			U32  *uint32  `json:",string"`
+			U64  *uint64  `json:",string"`
+			Uptr *uintptr `json:",string"`
+			Bool *bool    `json:",string"`
+		})(nil),
+		(*struct {
+			Struct struct{ Foo string } `json:",string"`
+			Arr    [2]int               `json:",string"`
+			Slice  []string             `json:",string"`
+			Map    map[int]int          `json:",string"`
+		})(nil),
+		(*struct {
 			Field bool `json:"中文"`
 		})(nil),
 	)

--- a/value_tests/struct_test.go
+++ b/value_tests/struct_test.go
@@ -105,6 +105,18 @@ func init() {
 			Asks      [][2]float64 `json:"asks"`
 		})(nil),
 		input: `{"key_string": "KEYSTRING","type": "TYPE","asks": [[1e+66,1]]}`,
+	}, unmarshalCase{
+		ptr:   (*quote)(nil),
+		input: `{"Str":null,"F32":null,"F64":null,"Int":null,"Uint":null,"I16":null,"I32":null,"I64":null,"U8":null,"U16":null,"U32":null,"U64":null,"Uptr":null,"Bool":null}`,
+	}, unmarshalCase{
+		ptr:   (*quote)(nil),
+		input: `{"Str":"\"foo\""}`,
+	}, unmarshalCase{
+		ptr: (*struct {
+			AnyStr interface{} `json:",string"`
+			AnyInt interface{} `json:",string"`
+		})(nil),
+		input: `{"AnyStr":"foo","AnyInt":123}`,
 	})
 	marshalCases = append(marshalCases,
 		struct {
@@ -204,6 +216,14 @@ func init() {
 		}{
 			"should not marshal",
 		},
+		quote{},
+		struct {
+			AnyStr interface{} `json:",string"`
+			AnyInt interface{} `json:",string"`
+		}{
+			AnyStr: "foo",
+			AnyInt: 123,
+		},
 	)
 }
 
@@ -244,4 +264,24 @@ type structOrder struct {
 	Field3 string
 	orderB
 	Field7 string
+}
+
+type quote struct {
+	// The ,string option applies only to fields of string, floating point, integer,
+	// or boolean types as per https://pkg.go.dev/encoding/json@go1.20.1.
+	// It is poorly or not totally documented that json.Marshal does not quote null.
+	Str  *string  `json:",string"`
+	F32  *float32 `json:",string"`
+	F64  *float64 `json:",string"`
+	Int  *int     `json:",string"`
+	Uint *uint    `json:",string"`
+	I16  *int16   `json:",string"`
+	I32  *int32   `json:",string"`
+	I64  *int64   `json:",string"`
+	U8   *uint8   `json:",string"`
+	U16  *uint16  `json:",string"`
+	U32  *uint32  `json:",string"`
+	U64  *uint64  `json:",string"`
+	Uptr *uintptr `json:",string"`
+	Bool *bool    `json:",string"`
 }


### PR DESCRIPTION
This is a PR that explores how to fix https://github.com/json-iterator/go/issues/657#issuecomment-1429702605.

The `json:",string"` option incorrectly quotes value even when it must not be applied.

If this patch is merged, it would not quote `nil`, or types other than string, boolean, numeric and pointer types that points to those. Also it would report error correctly.

```go
package main

import (
	"encoding/json"
	"fmt"

	jsoniter "github.com/json-iterator/go"
)

type quote struct {
	S *string `json:",string"`
}

func main() {
	var (
		q   quote
		err error
	)
	for idx, str := range []string{
		`{}`,
		`{"S":"\"234\""}`,
		`{"S":"\"\""}`,
		`{"S":"\""}`,
		`{"S":"234"}`,
		`{"S":234"}`,
		`{"S":"234}`,
	} {
		fmt.Printf("case %d, %s\n", idx, str)
		err = jsoniter.ConfigCompatibleWithStandardLibrary.Unmarshal([]byte(str), &q)
		fmt.Printf("jsoniter err: %+v\n", err)
		err = json.Unmarshal([]byte(str), &q)
		fmt.Printf("json err: %+v\n", err)
		fmt.Println()
	}
}

/*
case 0, {}
jsoniter err: <nil>
json err: <nil>

case 1, {"S":"\"234\""}
jsoniter err: <nil>
json err: <nil>

case 2, {"S":"\"\""}
jsoniter err: <nil>
json err: <nil>

case 3, {"S":"\""}
jsoniter err: main.quote.S: stringModeStringDecoder: expect len(s) >= 2, but found ", error found in #9 byte of ...|{"S":"\""}|..., bigger context ...|{"S":"\""}|...
json err: json: invalid use of ,string struct tag, trying to unmarshal "\"" into string

case 4, {"S":"234"}
jsoniter err: main.quote.S: stringModeStringDecoder: expect ", but found 2, error found in #10 byte of ...|{"S":"234"}|..., bigger context ...|{"S":"234"}|...
json err: json: invalid use of ,string struct tag, trying to unmarshal "234" into string

case 5, {"S":234"}
jsoniter err: main.quote.S: ReadString: expects " or n, but found 2, error found in #6 byte of ...|{"S":234"}|..., bigger context ...|{"S":234"}|...
json err: invalid character '"' after object key:value pair

case 6, {"S":"234}
jsoniter err: main.quote.S: readStringSlowPath: unexpected end of input, error found in #10 byte of ...|{"S":"234}|..., bigger context ...|{"S":"234}|...
json err: unexpected end of JSON input
*/
```