### PR TITLE
Fix wrong behavior in marshalling invalid UTF-8 byte with EscapeHTML=false

### DIFF
--- a/stream_str.go
+++ b/stream_str.go
@@ -315,7 +315,7 @@ func (stream *Stream) WriteString(s string) {
 	i := 0
 	for ; i < valLen; i++ {
 		c := s[i]
-		if c > 31 && c != '"' && c != '\\' {
+		if c < utf8.RuneSelf && safeSet[c] {
 			stream.buf = append(stream.buf, c)
 		} else {
 			break


### PR DESCRIPTION
See #663