### PR TITLE
allocate a 512 byte buffer if none exists during Iterator.Reset()

### DIFF
--- a/iter.go
+++ b/iter.go
@@ -130,6 +130,9 @@ func (iter *Iterator) Pool() IteratorPool {
 // Reset reuse iterator instance by specifying another reader
 func (iter *Iterator) Reset(reader io.Reader) *Iterator {
 	iter.reader = reader
+	if iter.buf == nil {
+		iter.buf = make([]byte, 512)
+	}
 	iter.head = 0
 	iter.tail = 0
 	iter.depth = 0


### PR DESCRIPTION
Reproduction code:
```go
iter := jsoniter.NewIterator(jsoniter.ConfigDefault).Reset(r)
t := iter.WhatIsNext()
```
This would block forever in the `WhatIsNext` function because no internal `item.buf` was allocated during `Iterator.Reset()` and `Iterator.loadMore()` will just endlessly try to fill the buffer here because the `.Read()` call with a nil buffer will immediately return without reading anything.
https://github.com/json-iterator/go/blob/71ac16282d122fdd1e3a6d3e7f79b79b4cc3b50e/iter.go#L265-L279

The change here is to just allocate a 512 byte buffer if there wasn't one defined before. I believe that it can be safely reused without having to clear it because we're working with the `iter.head` and `iter.tail` everywhere we're making use of it.