### PR TITLE
Add security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,19 @@
+# Security Policy
+
+If you have discovered a security vulnerability in this project, please report it
+privately. **Do not disclose it as a public issue.** This gives us time to work with you
+to fix the issue before public exposure, reducing the chance that the exploit will be
+used before a patch is released.
+
+You may submit the report in the following ways:
+
+- send an email to taowen@gmail.com; and/or
+- send us a [private vulnerability report](https://github.com/json-iterator/go/security/advisories/new)
+
+Please provide the following information in your report:
+
+- A description of the vulnerability and its impact
+- How to reproduce the issue
+
+This project is maintained by volunteers on a reasonable-effort basis. As such,
+we ask that you give us 90 days to work on a fix before public exposure.


### PR DESCRIPTION
Fixes #674.

This PR adds a security policy (see the linked issue for details).

The policy currently accepts reports via email (to the address at the end of the README) or using GitHub's private reporting feature. If you only use to adopt one of these (or change the email, or anything else!), let me know and I'll happily edit the PR.