### PR TITLE
Faster ReadString by avoiding memory allocations in []byte to string conversion

### DIFF
--- a/b2s_new.go
+++ b/b2s_new.go
@@ -1,0 +1,12 @@
+//go:build go1.20
+// +build go1.20
+
+package jsoniter
+
+import "unsafe"
+
+// b2s converts byte slice to a string without memory allocation.
+// See https://groups.google.com/forum/#!msg/Golang-Nuts/ENgbUzYvCuU/90yGx7GUAgAJ .
+func b2s(b []byte) string {
+	return unsafe.String(unsafe.SliceData(b), len(b))
+}

--- a/b2s_old.go
+++ b/b2s_old.go
@@ -1,0 +1,15 @@
+//go:build !go1.20
+// +build !go1.20
+
+package jsoniter
+
+import "unsafe"
+
+// b2s converts byte slice to a string without memory allocation.
+// See https://groups.google.com/forum/#!msg/Golang-Nuts/ENgbUzYvCuU/90yGx7GUAgAJ .
+//
+// Note it may break if string and/or slice header will change
+// in the future go versions.
+func b2s(b []byte) string {
+	return *(*string)(unsafe.Pointer(&b))
+}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/json-iterator/go
 
-go 1.12
+go 1.20
 
 require (
 	github.com/davecgh/go-spew v1.1.1
@@ -8,4 +8,9 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421
 	github.com/modern-go/reflect2 v1.0.2
 	github.com/stretchr/testify v1.8.0
+)
+
+require (
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/iter_str.go
+++ b/iter_str.go
@@ -12,7 +12,7 @@ func (iter *Iterator) ReadString() (ret string) {
 		for i := iter.head; i < iter.tail; i++ {
 			c := iter.buf[i]
 			if c == '"' {
-				ret = string(iter.buf[iter.head:i])
+				ret = b2s(iter.buf[iter.head:i])
 				iter.head = i + 1
 				return ret
 			} else if c == '\\' {
@@ -38,7 +38,7 @@ func (iter *Iterator) readStringSlowPath() (ret string) {
 	for iter.Error == nil {
 		c = iter.readByte()
 		if c == '"' {
-			return string(str)
+			return b2s(str)
 		}
 		if c == '\\' {
 			c = iter.readByte()


### PR DESCRIPTION
Benchstat results:
```
name                    old time/op    new time/op    delta
_jsoniter_large_file      10.8µs ± 6%     8.9µs ± 7%  -17.69%  (p=0.000 n=10+10)
_jsoniter_large_file-2    10.6µs ±10%     9.2µs ± 5%  -13.07%  (p=0.000 n=10+10)
_jsoniter_large_file-4    10.9µs ±10%     9.2µs ± 9%  -14.91%  (p=0.000 n=10+10)

name                    old alloc/op   new alloc/op   delta
_jsoniter_large_file      4.91kB ± 0%    4.37kB ± 0%  -11.07%  (p=0.000 n=10+10)
_jsoniter_large_file-2    4.91kB ± 0%    4.37kB ± 0%  -11.07%  (p=0.000 n=10+10)
_jsoniter_large_file-4    4.91kB ± 0%    4.37kB ± 0%  -11.07%  (p=0.000 n=10+10)

name                    old allocs/op  new allocs/op  delta
_jsoniter_large_file        78.0 ± 0%       5.0 ± 0%  -93.59%  (p=0.000 n=10+10)
_jsoniter_large_file-2      78.0 ± 0%       5.0 ± 0%  -93.59%  (p=0.000 n=10+10)
_jsoniter_large_file-4      78.0 ± 0%       5.0 ± 0%  -93.59%  (p=0.000 n=10+10)
```