### PR TITLE
Fix Typo in adapter.go

### DIFF
--- a/adapter.go
+++ b/adapter.go
@@ -60,7 +60,7 @@ type Decoder struct {
 	iter *Iterator
 }
 
-// Decode decode JSON into interface{}
+// Decode JSON into interface{}
 func (adapter *Decoder) Decode(obj interface{}) error {
 	if adapter.iter.head == adapter.iter.tail && adapter.iter.reader != nil {
 		if !adapter.iter.loadMore() {


### PR DESCRIPTION
The comment on line 63, has the word Decode written twice. This change corrects the typo.