### PR TITLE
Use ReadStringAsSlice instead of ReadString 

### DIFF
--- a/any.go
+++ b/any.go
@@ -3,11 +3,12 @@ package jsoniter
 import (
 	"errors"
 	"fmt"
-	"github.com/modern-go/reflect2"
 	"io"
 	"reflect"
 	"strconv"
 	"unsafe"
+
+	"github.com/modern-go/reflect2"
 )
 
 // Any generic object representation.
@@ -155,7 +156,7 @@ func (iter *Iterator) readAny() Any {
 	switch c {
 	case '"':
 		iter.unreadByte()
-		return &stringAny{baseAny{}, iter.ReadString()}
+		return &stringAny{baseAny{}, string(iter.ReadStringAsSlice())}
 	case 'n':
 		iter.skipThreeBytes('u', 'l', 'l') // null
 		return &nilAny{}

--- a/extra/binary_as_string_codec.go
+++ b/extra/binary_as_string_codec.go
@@ -1,10 +1,12 @@
 package extra
 
 import (
-	"github.com/json-iterator/go"
-	"github.com/modern-go/reflect2"
 	"unicode/utf8"
 	"unsafe"
+
+	"github.com/modern-go/reflect2"
+
+	"github.com/json-iterator/go"
 )
 
 // safeSet holds the value true if the ASCII character with the given array
@@ -142,19 +144,14 @@ func (codec *binaryAsStringCodec) Decode(ptr unsafe.Pointer, iter *jsoniter.Iter
 		b := rawBytes[i]
 		if b == '\\' {
 			b2 := rawBytes[i+1]
-			if b2 != '\\' {
-				iter.ReportError("decode binary as string", `\\x is only supported escape`)
+			if b2 != 'x' {
+				iter.ReportError("decode binary as string", `\x is only supported escape`)
 				return
 			}
 			b3 := rawBytes[i+2]
-			if b3 != 'x' {
-				iter.ReportError("decode binary as string", `\\x is only supported escape`)
-				return
-			}
 			b4 := rawBytes[i+3]
-			b5 := rawBytes[i+4]
-			i += 4
-			b = readHex(iter, b4, b5)
+			i += 3
+			b = readHex(iter, b3, b4)
 		}
 		bytes = append(bytes, b)
 	}

--- a/iter_skip_strict.go
+++ b/iter_skip_strict.go
@@ -1,4 +1,5 @@
-//+build !jsoniter_sloppy
+//go:build !jsoniter_sloppy
+// +build !jsoniter_sloppy
 
 package jsoniter
 
@@ -61,7 +62,7 @@ func (iter *Iterator) trySkipNumber() bool {
 func (iter *Iterator) skipString() {
 	if !iter.trySkipString() {
 		iter.unreadByte()
-		iter.ReadString()
+		iter.ReadStringAsSlice()
 	}
 }
 

--- a/misc_tests/jsoniter_object_test.go
+++ b/misc_tests/jsoniter_object_test.go
@@ -3,12 +3,13 @@ package misc_tests
 import (
 	"bytes"
 	"reflect"
+	"strings"
 	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
 
 	"github.com/json-iterator/go"
-	"github.com/stretchr/testify/require"
-	"strings"
-	"time"
 )
 
 func Test_empty_object(t *testing.T) {

--- a/reflect_json_number.go
+++ b/reflect_json_number.go
@@ -2,9 +2,10 @@ package jsoniter
 
 import (
 	"encoding/json"
-	"github.com/modern-go/reflect2"
 	"strconv"
 	"unsafe"
+
+	"github.com/modern-go/reflect2"
 )
 
 type Number string
@@ -61,7 +62,7 @@ type jsonNumberCodec struct {
 func (codec *jsonNumberCodec) Decode(ptr unsafe.Pointer, iter *Iterator) {
 	switch iter.WhatIsNext() {
 	case StringValue:
-		*((*json.Number)(ptr)) = json.Number(iter.ReadString())
+		*((*json.Number)(ptr)) = json.Number(iter.ReadStringAsSlice())
 	case NilValue:
 		iter.skipFourBytes('n', 'u', 'l', 'l')
 		*((*json.Number)(ptr)) = ""
@@ -89,12 +90,14 @@ type jsoniterNumberCodec struct {
 func (codec *jsoniterNumberCodec) Decode(ptr unsafe.Pointer, iter *Iterator) {
 	switch iter.WhatIsNext() {
 	case StringValue:
-		*((*Number)(ptr)) = Number(iter.ReadString())
+		num := iter.ReadStringAsSlice()
+		*((*Number)(ptr)) = Number(string(num))
 	case NilValue:
 		iter.skipFourBytes('n', 'u', 'l', 'l')
 		*((*Number)(ptr)) = ""
 	default:
-		*((*Number)(ptr)) = Number([]byte(iter.readNumberAsString()))
+		num := iter.ReadStringAsSlice()
+		*((*Number)(ptr)) = Number(string(num))
 	}
 }
 

--- a/reflect_map.go
+++ b/reflect_map.go
@@ -305,7 +305,7 @@ func (encoder *sortKeysMapEncoder) Encode(ptr unsafe.Pointer, stream *Stream) {
 		}
 		encodedKey := subStream.Buffer()[subStreamIndex:]
 		subIter.ResetBytes(encodedKey)
-		decodedKey := subIter.ReadString()
+		decodedKey := string(subIter.ReadStringAsSlice())
 		if stream.indention > 0 {
 			subStream.writeTwoBytes(byte(':'), byte(' '))
 		} else {

--- a/reflect_marshaler.go
+++ b/reflect_marshaler.go
@@ -217,8 +217,8 @@ func (decoder *textUnmarshalerDecoder) Decode(ptr unsafe.Pointer, iter *Iterator
 		obj = valType.UnsafeIndirect(ptr)
 	}
 	unmarshaler := (obj).(encoding.TextUnmarshaler)
-	str := iter.ReadString()
-	err := unmarshaler.UnmarshalText([]byte(str))
+	str := iter.ReadStringAsSlice()
+	err := unmarshaler.UnmarshalText(str)
 	if err != nil {
 		iter.ReportError("textUnmarshalerDecoder", err.Error())
 	}

--- a/reflect_native.go
+++ b/reflect_native.go
@@ -206,7 +206,8 @@ type stringCodec struct {
 }
 
 func (codec *stringCodec) Decode(ptr unsafe.Pointer, iter *Iterator) {
-	*((*string)(ptr)) = iter.ReadString()
+	data := iter.ReadStringAsSlice()
+	*((*string)(ptr)) = string(data)
 }
 
 func (codec *stringCodec) Encode(ptr unsafe.Pointer, stream *Stream) {
@@ -417,8 +418,8 @@ func (codec *base64Codec) Decode(ptr unsafe.Pointer, iter *Iterator) {
 	}
 	switch iter.WhatIsNext() {
 	case StringValue:
-		src := iter.ReadString()
-		dst, err := base64.StdEncoding.DecodeString(src)
+		src := iter.ReadStringAsSlice()
+		dst, err := base64.StdEncoding.DecodeString(string(src))
 		if err != nil {
 			iter.ReportError("decode base64", err.Error())
 		} else {

--- a/reflect_struct_decoder.go
+++ b/reflect_struct_decoder.go
@@ -517,15 +517,8 @@ func (decoder *generalStructDecoder) Decode(ptr unsafe.Pointer, iter *Iterator) 
 }
 
 func (decoder *generalStructDecoder) decodeOneField(ptr unsafe.Pointer, iter *Iterator) {
-	var field string
-	var fieldDecoder *structFieldDecoder
-	if iter.cfg.objectFieldMustBeSimpleString {
-		fieldBytes := iter.ReadStringAsSlice()
-		field = *(*string)(unsafe.Pointer(&fieldBytes))
-	} else {
-		field = string(iter.ReadStringAsSlice())
-	}
-	fieldDecoder = decoder.fields[field]
+	field := string(iter.ReadStringAsSlice())
+	fieldDecoder := decoder.fields[field]
 	if fieldDecoder == nil && !iter.cfg.caseSensitive {
 		fieldDecoder = decoder.fields[strings.ToLower(field)]
 	}

--- a/reflect_struct_decoder.go
+++ b/reflect_struct_decoder.go
@@ -522,16 +522,12 @@ func (decoder *generalStructDecoder) decodeOneField(ptr unsafe.Pointer, iter *It
 	if iter.cfg.objectFieldMustBeSimpleString {
 		fieldBytes := iter.ReadStringAsSlice()
 		field = *(*string)(unsafe.Pointer(&fieldBytes))
-		fieldDecoder = decoder.fields[field]
-		if fieldDecoder == nil && !iter.cfg.caseSensitive {
-			fieldDecoder = decoder.fields[strings.ToLower(field)]
-		}
 	} else {
-		field = iter.ReadString()
-		fieldDecoder = decoder.fields[field]
-		if fieldDecoder == nil && !iter.cfg.caseSensitive {
-			fieldDecoder = decoder.fields[strings.ToLower(field)]
-		}
+		field = string(iter.ReadStringAsSlice())
+	}
+	fieldDecoder = decoder.fields[field]
+	if fieldDecoder == nil && !iter.cfg.caseSensitive {
+		fieldDecoder = decoder.fields[strings.ToLower(field)]
 	}
 	if fieldDecoder == nil {
 		if decoder.disallowUnknownFields {
@@ -1067,7 +1063,8 @@ func (decoder *stringModeStringDecoder) Decode(ptr unsafe.Pointer, iter *Iterato
 	str := *((*string)(ptr))
 	tempIter := decoder.cfg.BorrowIterator([]byte(str))
 	defer decoder.cfg.ReturnIterator(tempIter)
-	*((*string)(ptr)) = tempIter.ReadString()
+	data := tempIter.ReadStringAsSlice()
+	*((*string)(ptr)) = string(data)
 }
 
 type stringModeNumberDecoder struct {


### PR DESCRIPTION
Returning `string([]byte)` escapes to heap
Cast to string by receiver, if needed