### PR TITLE
Prevent panic on self-referencing structs/map/slices during Marshal

### DIFF
--- a/reflect.go
+++ b/reflect.go
@@ -270,7 +270,7 @@ func _createEncoderOfType(ctx *ctx, typ reflect2.Type) ValEncoder {
 	kind := typ.Kind()
 	switch kind {
 	case reflect.Interface:
-		return &dynamicEncoder{typ}
+		return &dynamicEncoder{valType: typ, seen: make(map[unsafe.Pointer]bool, 1)}
 	case reflect.Struct:
 		return encoderOfStruct(ctx, typ)
 	case reflect.Array:

--- a/reflect_extension.go
+++ b/reflect_extension.go
@@ -2,12 +2,13 @@ package jsoniter
 
 import (
 	"fmt"
-	"github.com/modern-go/reflect2"
 	"reflect"
 	"sort"
 	"strings"
 	"unicode"
 	"unsafe"
+
+	"github.com/modern-go/reflect2"
 )
 
 var typeDecoders = map[string]ValDecoder{}
@@ -325,7 +326,7 @@ func _getTypeEncoderFromExtension(ctx *ctx, typ reflect2.Type) ValEncoder {
 		typePtr := typ.(*reflect2.UnsafePtrType)
 		encoder := typeEncoders[typePtr.Elem().String()]
 		if encoder != nil {
-			return &OptionalEncoder{encoder}
+			return &OptionalEncoder{ValueEncoder: encoder, seen: make(map[unsafe.Pointer]bool, 1)}
 		}
 	}
 	return nil

--- a/reflect_struct_encoder.go
+++ b/reflect_struct_encoder.go
@@ -2,10 +2,11 @@ package jsoniter
 
 import (
 	"fmt"
-	"github.com/modern-go/reflect2"
 	"io"
 	"reflect"
 	"unsafe"
+
+	"github.com/modern-go/reflect2"
 )
 
 func encoderOfStruct(ctx *ctx, typ reflect2.Type) ValEncoder {
@@ -54,7 +55,7 @@ func createCheckIsEmpty(ctx *ctx, typ reflect2.Type) checkIsEmpty {
 	kind := typ.Kind()
 	switch kind {
 	case reflect.Interface:
-		return &dynamicEncoder{typ}
+		return &dynamicEncoder{valType: typ, seen: make(map[unsafe.Pointer]bool, 1)}
 	case reflect.Struct:
 		return &structEncoder{typ: typ}
 	case reflect.Array:

--- a/stream.go
+++ b/stream.go
@@ -1,8 +1,11 @@
 package jsoniter
 
 import (
+	"errors"
 	"io"
 )
+
+var ErrEncounterCycle = errors.New("encountered a cycle")
 
 // stream is a io.Writer like object, with JSON specific write functions.
 // Error is not returned as return value, but stored as Error member on this stream instance.

--- a/value_tests/map_test.go
+++ b/value_tests/map_test.go
@@ -57,9 +57,13 @@ func init() {
         "2018-12-14": true
     	}`,
 	}, unmarshalCase{
-		ptr: (*map[customKey]string)(nil),
+		ptr:   (*map[customKey]string)(nil),
 		input: `{"foo": "bar"}`,
 	})
+
+	selfRecursive := map[string]interface{}{}
+	selfRecursive["me"] = selfRecursive
+	marshalSelfRecursiveCases = append(marshalSelfRecursiveCases, selfRecursive)
 }
 
 type MyInterface interface {

--- a/value_tests/slice_test.go
+++ b/value_tests/slice_test.go
@@ -24,4 +24,8 @@ func init() {
 		ptr:   (*[]byte)(nil),
 		input: `"c3ViamVjdHM\/X2Q9MQ=="`,
 	})
+
+	selfRecursive := []interface{}{nil}
+	selfRecursive[0] = selfRecursive
+	marshalSelfRecursiveCases = append(marshalSelfRecursiveCases, selfRecursive)
 }

--- a/value_tests/struct_test.go
+++ b/value_tests/struct_test.go
@@ -205,6 +205,10 @@ func init() {
 			"should not marshal",
 		},
 	)
+
+	selfRecursive := &structRecursive{}
+	selfRecursive.Me = selfRecursive
+	marshalSelfRecursiveCases = append(marshalSelfRecursiveCases, selfRecursive)
 }
 
 type StructVarious struct {

--- a/value_tests/value_test.go
+++ b/value_tests/value_test.go
@@ -3,10 +3,11 @@ package test
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/json-iterator/go"
+	"testing"
+
+	jsoniter "github.com/json-iterator/go"
 	"github.com/modern-go/reflect2"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 type unmarshalCase struct {
@@ -21,6 +22,8 @@ var unmarshalCases []unmarshalCase
 var marshalCases = []interface{}{
 	nil,
 }
+
+var marshalSelfRecursiveCases = []interface{}{}
 
 type selectedMarshalCase struct {
 	marshalCase interface{}
@@ -75,6 +78,18 @@ func Test_marshal(t *testing.T) {
 			output2, err2 := jsoniter.ConfigCompatibleWithStandardLibrary.Marshal(testCase)
 			should.NoError(err2, "jsoniter")
 			should.Equal(string(output1), string(output2))
+		})
+	}
+}
+
+func Test_marshal_self_recursive(t *testing.T) {
+	for i, testCase := range marshalSelfRecursiveCases {
+		t.Run(fmt.Sprintf("[%v]%s", i, reflect2.TypeOf(testCase).String()), func(t *testing.T) {
+			should := require.New(t)
+			_, err1 := json.Marshal(testCase)
+			should.ErrorContains(err1, "encountered a cycle")
+			_, err2 := jsoniter.ConfigCompatibleWithStandardLibrary.Marshal(testCase)
+			should.ErrorContains(err2, "encountered a cycle")
 		})
 	}
 }


### PR DESCRIPTION
This PR fixes a bug in `Marshal` where it would panic when attempting to serialize self-referencing structs or slices.

Previously, encountering these data structures would cause a panic, making it difficult to handle these situations gracefully. This change modifies `Marshal` to return an error instead, providing a more consistent and predictable way to handle serialization errors. This aligns the behavior with `json.Marshal`, which also returns an error when encountering self-referencing data structures.

This improvement enhances the robustness of the library and makes it easier to handle potential errors during serialization.