### PR TITLE
Added for b.Loop() in benchmarks functions

### DIFF
--- a/benchmarks/encode_string_test.go
+++ b/benchmarks/encode_string_test.go
@@ -2,8 +2,9 @@ package test
 
 import (
 	"bytes"
-	"github.com/json-iterator/go"
 	"testing"
+
+	jsoniter "github.com/json-iterator/go"
 )
 
 func Benchmark_encode_string_with_SetEscapeHTML(b *testing.B) {
@@ -14,7 +15,7 @@ func Benchmark_encode_string_with_SetEscapeHTML(b *testing.B) {
 	}
 	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	b.ReportAllocs()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		buf := &bytes.Buffer{}
 		enc := json.NewEncoder(buf)
 		enc.SetEscapeHTML(true)

--- a/benchmarks/jsoniter_large_file_test.go
+++ b/benchmarks/jsoniter_large_file_test.go
@@ -2,10 +2,11 @@ package test
 
 import (
 	"encoding/json"
-	"github.com/json-iterator/go"
 	"io/ioutil"
 	"os"
 	"testing"
+
+	jsoniter "github.com/json-iterator/go"
 )
 
 //func Test_large_file(t *testing.T) {
@@ -126,7 +127,7 @@ func init() {
 */
 func Benchmark_jsoniter_large_file(b *testing.B) {
 	b.ReportAllocs()
-	for n := 0; n < b.N; n++ {
+	for b.Loop() {
 		file, _ := os.Open("/tmp/large-file.json")
 		iter := jsoniter.Parse(jsoniter.ConfigDefault, file, 4096)
 		count := 0
@@ -145,7 +146,7 @@ func Benchmark_jsoniter_large_file(b *testing.B) {
 
 func Benchmark_json_large_file(b *testing.B) {
 	b.ReportAllocs()
-	for n := 0; n < b.N; n++ {
+	for b.Loop() {
 		file, _ := os.Open("/tmp/large-file.json")
 		bytes, _ := ioutil.ReadAll(file)
 		file.Close()

--- a/benchmarks/stream_test.go
+++ b/benchmarks/stream_test.go
@@ -11,7 +11,7 @@ import (
 func Benchmark_stream_encode_big_object(b *testing.B) {
 	var buf bytes.Buffer
 	var stream = jsoniter.NewStream(jsoniter.ConfigDefault, &buf, 100)
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		buf.Reset()
 		stream.Reset(&buf)
 		encodeObject(stream)


### PR DESCRIPTION
PR based on [https://go.dev/blog/testing-b-loop](url) for Go 1.24.