### PR TITLE
Cycle check

### DIFF
--- a/any_tests/jsoniter_any_object_test.go
+++ b/any_tests/jsoniter_any_object_test.go
@@ -3,7 +3,7 @@ package any_tests
 import (
 	"testing"
 
-	"github.com/json-iterator/go"
+	jsoniter "github.com/json-iterator/go"
 	"github.com/stretchr/testify/require"
 )
 

--- a/api_tests/marshal_json_test.go
+++ b/api_tests/marshal_json_test.go
@@ -3,11 +3,12 @@ package test
 import (
 	"bytes"
 	"encoding/json"
-	"github.com/json-iterator/go"
+	"errors"
 	"testing"
+
+	jsoniter "github.com/json-iterator/go"
 	"github.com/stretchr/testify/require"
 )
-
 
 type Foo struct {
 	Bar interface{}
@@ -19,11 +20,10 @@ func (f Foo) MarshalJSON() ([]byte, error) {
 	return buf.Bytes(), err
 }
 
-
 // Standard Encoder has trailing newline.
 func TestEncodeMarshalJSON(t *testing.T) {
 
-	foo := Foo {
+	foo := Foo{
 		Bar: 123,
 	}
 	should := require.New(t)
@@ -33,4 +33,22 @@ func TestEncodeMarshalJSON(t *testing.T) {
 	stdenc := json.NewEncoder(&stdbuf)
 	stdenc.Encode(foo)
 	should.Equal(stdbuf.Bytes(), buf.Bytes())
+}
+
+func TestMarshalObjectWithCycle(t *testing.T) {
+	type A struct {
+		A *A
+	}
+	a := A{}
+	a.A = &a
+
+	api := jsoniter.ConfigCompatibleWithStandardLibrary
+
+	if _, err := jsoniter.Marshal(a); !errors.Is(err, jsoniter.ErrCycleEncountered) {
+		t.Fatal(err)
+	}
+
+	if err := api.NewEncoder(nil).Encode(a); !errors.Is(err, jsoniter.ErrCycleEncountered) {
+		t.Fatal(err)
+	}
 }

--- a/config.go
+++ b/config.go
@@ -2,6 +2,7 @@ package jsoniter
 
 import (
 	"encoding/json"
+	"fmt"
 	"io"
 	"reflect"
 	"sync"
@@ -284,26 +285,70 @@ func (cfg *frozenConfig) cleanEncoders() {
 }
 
 func (cfg *frozenConfig) MarshalToString(v interface{}) (string, error) {
-	stream := cfg.BorrowStream(nil)
-	defer cfg.ReturnStream(stream)
-	stream.WriteVal(v)
-	if stream.Error != nil {
-		return "", stream.Error
+	result, err := cfg.marshalToStream(v)
+	if err != nil {
+		return "", err
 	}
-	return string(stream.Buffer()), nil
+
+	return string(result), nil
 }
 
 func (cfg *frozenConfig) Marshal(v interface{}) ([]byte, error) {
+	result, err := cfg.marshalToStream(v)
+	if err != nil {
+		return nil, err
+	}
+
+	copied := make([]byte, len(result))
+	copy(copied, result)
+	return copied, nil
+}
+
+func hasCycle(v interface{}) bool {
+	visited := make(map[uintptr]bool)
+	queue := []reflect.Value{reflect.ValueOf(v)}
+
+	for len(queue) > 0 {
+		val := queue[0]
+		queue = queue[1:]
+
+		for val.Kind() == reflect.Ptr || val.Kind() == reflect.Interface {
+			if val.IsNil() {
+				break
+			}
+			if val.Kind() == reflect.Ptr {
+				ptr := val.Pointer()
+				if visited[ptr] {
+					return true
+				}
+				visited[ptr] = true
+			}
+			val = val.Elem()
+		}
+
+		if val.Kind() == reflect.Struct {
+			for i := 0; i < val.NumField(); i++ {
+				queue = append(queue, val.Field(i))
+			}
+		}
+	}
+	return false
+}
+
+// marshalToStream writes v to a borrowed stream and returns stream.Buffer() with error.
+func (cfg *frozenConfig) marshalToStream(v interface{}) ([]byte, error) {
+	if hasCycle(v) {
+		return nil, fmt.Errorf("jsoniter: unsupported type: encountered a cycle")
+	}
+
 	stream := cfg.BorrowStream(nil)
 	defer cfg.ReturnStream(stream)
+
 	stream.WriteVal(v)
 	if stream.Error != nil {
 		return nil, stream.Error
 	}
-	result := stream.Buffer()
-	copied := make([]byte, len(result))
-	copy(copied, result)
-	return copied, nil
+	return stream.Buffer(), nil
 }
 
 func (cfg *frozenConfig) MarshalIndent(v interface{}, prefix, indent string) ([]byte, error) {

--- a/config.go
+++ b/config.go
@@ -2,7 +2,6 @@ package jsoniter
 
 import (
 	"encoding/json"
-	"fmt"
 	"io"
 	"reflect"
 	"sync"
@@ -304,43 +303,8 @@ func (cfg *frozenConfig) Marshal(v interface{}) ([]byte, error) {
 	return copied, nil
 }
 
-func hasCycle(v interface{}) bool {
-	visited := make(map[uintptr]bool)
-	queue := []reflect.Value{reflect.ValueOf(v)}
-
-	for len(queue) > 0 {
-		val := queue[0]
-		queue = queue[1:]
-
-		for val.Kind() == reflect.Ptr || val.Kind() == reflect.Interface {
-			if val.IsNil() {
-				break
-			}
-			if val.Kind() == reflect.Ptr {
-				ptr := val.Pointer()
-				if visited[ptr] {
-					return true
-				}
-				visited[ptr] = true
-			}
-			val = val.Elem()
-		}
-
-		if val.Kind() == reflect.Struct {
-			for i := 0; i < val.NumField(); i++ {
-				queue = append(queue, val.Field(i))
-			}
-		}
-	}
-	return false
-}
-
 // marshalToStream writes v to a borrowed stream and returns stream.Buffer() with error.
 func (cfg *frozenConfig) marshalToStream(v interface{}) ([]byte, error) {
-	if hasCycle(v) {
-		return nil, fmt.Errorf("jsoniter: unsupported type: encountered a cycle")
-	}
-
 	stream := cfg.BorrowStream(nil)
 	defer cfg.ReturnStream(stream)
 

--- a/reflect.go
+++ b/reflect.go
@@ -119,15 +119,16 @@ var ErrCycleEncountered = errors.New("jsoniter: unsupported type: encountered a 
 
 // WriteVal copy the go interface into underlying JSON, same as json.Marshal
 func (stream *Stream) WriteVal(val interface{}) {
+	if val == nil {
+		stream.WriteNil()
+		return
+	}
+
 	if hasCycle(val) {
 		stream.Error = ErrCycleEncountered
 		return
 	}
 
-	if val == nil {
-		stream.WriteNil()
-		return
-	}
 	cacheKey := reflect2.RTypeOf(val)
 	encoder := stream.cfg.getEncoderFromCache(cacheKey)
 	if encoder == nil {

--- a/reflect.go
+++ b/reflect.go
@@ -115,12 +115,12 @@ func hasCycle(v interface{}) bool {
 	return false
 }
 
-var errCycleEncountered = errors.New("jsoniter: unsupported type: encountered a cycle")
+var ErrCycleEncountered = errors.New("jsoniter: unsupported type: encountered a cycle")
 
 // WriteVal copy the go interface into underlying JSON, same as json.Marshal
 func (stream *Stream) WriteVal(val interface{}) {
 	if hasCycle(val) {
-		stream.Error = errCycleEncountered
+		stream.Error = ErrCycleEncountered
 		return
 	}
 

--- a/reflect.go
+++ b/reflect.go
@@ -85,7 +85,7 @@ func (iter *Iterator) ReadVal(obj interface{}) {
 
 // WriteVal copy the go interface into underlying JSON, same as json.Marshal
 func (stream *Stream) WriteVal(val interface{}) {
-	if nil == val {
+	if val == nil {
 		stream.WriteNil()
 		return
 	}

--- a/reflect.go
+++ b/reflect.go
@@ -1,6 +1,7 @@
 package jsoniter
 
 import (
+	"errors"
 	"fmt"
 	"reflect"
 	"unsafe"
@@ -83,8 +84,46 @@ func (iter *Iterator) ReadVal(obj interface{}) {
 	}
 }
 
+func hasCycle(v interface{}) bool {
+	visited := make(map[uintptr]bool)
+	queue := []reflect.Value{reflect.ValueOf(v)}
+
+	for len(queue) > 0 {
+		val := queue[0]
+		queue = queue[1:]
+
+		for val.Kind() == reflect.Ptr || val.Kind() == reflect.Interface {
+			if val.IsNil() {
+				break
+			}
+			if val.Kind() == reflect.Ptr {
+				ptr := val.Pointer()
+				if visited[ptr] {
+					return true
+				}
+				visited[ptr] = true
+			}
+			val = val.Elem()
+		}
+
+		if val.Kind() == reflect.Struct {
+			for i := 0; i < val.NumField(); i++ {
+				queue = append(queue, val.Field(i))
+			}
+		}
+	}
+	return false
+}
+
+var errCycleEncountered = errors.New("jsoniter: unsupported type: encountered a cycle")
+
 // WriteVal copy the go interface into underlying JSON, same as json.Marshal
 func (stream *Stream) WriteVal(val interface{}) {
+	if hasCycle(val) {
+		stream.Error = errCycleEncountered
+		return
+	}
+
 	if val == nil {
 		stream.WriteNil()
 		return


### PR DESCRIPTION
As described in issue https://github.com/json-iterator/go/issues/696, cyclic dependencies between structs cause a stack overflow. In this PR, I have added a hasCycle(v) function to check an object for cycles before marshaling it.